### PR TITLE
Update note links

### DIFF
--- a/components/editor/EditorElement.tsx
+++ b/components/editor/EditorElement.tsx
@@ -141,14 +141,14 @@ const NoteLinkElement = (props: NoteLinkElementProps) => {
           contentEditable={false}
           {...attributes}
         >
-          {element.noteTitle}
+          {element.customText ?? element.noteTitle}
           {children}
         </span>
       ) : (
         <span>
           <Link href={`/app/note/${element.noteId}`}>
             <a className={className} contentEditable={false} {...attributes}>
-              {element.noteTitle}
+              {element.customText ?? element.noteTitle}
               {children}
             </a>
           </Link>

--- a/components/editor/EditorElement.tsx
+++ b/components/editor/EditorElement.tsx
@@ -1,5 +1,5 @@
 import { ReactNode } from 'react';
-import type { RenderElementProps } from 'slate-react';
+import { RenderElementProps, useFocused, useSelected } from 'slate-react';
 import Tippy from '@tippyjs/react';
 import Link from 'next/link';
 import type { ExternalLink, NoteLink } from 'types/slate';
@@ -87,7 +87,7 @@ export default function EditorElement(props: Props) {
     case ElementType.CodeBlock:
       return (
         <code
-          className={`block p-2 bg-gray-100 rounded text-primary-800 ${
+          className={`block p-2 bg-gray-100 border border-gray-200 rounded ${
             omitVerticalSpacing ? '' : 'my-3'
           }`}
           {...attributes}
@@ -126,21 +126,29 @@ const NoteLinkElement = (props: NoteLinkElementProps) => {
   const { element, children, attributes } = props;
   const onNoteLinkClick = useOnNoteLinkClick();
   const isPageStackingOn = useStore((state) => state.isPageStackingOn);
+  const selected = useSelected();
+  const focused = useFocused();
+  const className = `p-1 rounded text-primary-600 cursor-pointer bg-gray-100 hover:bg-gray-200 active:bg-gray-300 ${
+    selected && focused ? 'bg-blue-100' : ''
+  }`;
 
   return (
     <Tippy content={element.noteTitle} duration={0} placement="bottom">
       {isPageStackingOn ? (
         <span
-          className="link"
+          className={className}
           onClick={() => onNoteLinkClick(element.noteId)}
+          contentEditable={false}
           {...attributes}
         >
+          {element.noteTitle}
           {children}
         </span>
       ) : (
         <span>
           <Link href={`/app/note/${element.noteId}`}>
-            <a className="link" {...attributes}>
+            <a className={className} contentEditable={false} {...attributes}>
+              {element.noteTitle}
               {children}
             </a>
           </Link>

--- a/components/editor/EditorLeaf.tsx
+++ b/components/editor/EditorLeaf.tsx
@@ -7,7 +7,7 @@ const EditorLeaf = ({ attributes, children, leaf }: RenderLeafProps) => {
 
   if (leaf.code) {
     children = (
-      <code className="p-1 bg-gray-100 rounded text-primary-800">
+      <code className="p-1 bg-gray-100 border border-gray-200 rounded">
         {children}
       </code>
     );

--- a/components/editor/ReadOnlyEditor.tsx
+++ b/components/editor/ReadOnlyEditor.tsx
@@ -1,7 +1,7 @@
 import { ReactNode } from 'react';
 import { Descendant, Element as SlateElement } from 'slate';
 import { RenderElementProps, RenderLeafProps } from 'slate-react';
-import { FormattedText } from 'types/slate';
+import { ElementType, FormattedText } from 'types/slate';
 
 type Props = {
   value: Descendant[];
@@ -37,7 +37,7 @@ const Children = (props: ChildrenProps) => {
               key={i}
               element={child}
               renderElement={renderElement}
-              renderLeaf={renderLeaf}
+              renderLeaf={!isVoid(child) ? renderLeaf : () => null}
             />
           );
         } else {
@@ -93,3 +93,7 @@ function Leaf(props: LeafProps) {
     </>
   );
 }
+
+const isVoid = (element: SlateElement) => {
+  return element.type === ElementType.NoteLink;
+};

--- a/editor/formatting.ts
+++ b/editor/formatting.ts
@@ -183,7 +183,7 @@ export const insertNoteLink = (
     noteId,
     noteTitle,
     customText: !isCollapsed ? Editor.string(editor, selection) : undefined,
-    children: [],
+    children: [{ text: '' }],
   };
   wrapLink(editor, link);
 };

--- a/editor/formatting.ts
+++ b/editor/formatting.ts
@@ -183,7 +183,7 @@ export const insertNoteLink = (
     noteId,
     noteTitle,
     customText: !isCollapsed ? Editor.string(editor, selection) : undefined,
-    children: [{ text: '' }],
+    children: isCollapsed ? [{ text: noteTitle }] : [],
   };
   wrapLink(editor, link);
 };

--- a/editor/formatting.ts
+++ b/editor/formatting.ts
@@ -182,8 +182,8 @@ export const insertNoteLink = (
     type: ElementType.NoteLink,
     noteId,
     noteTitle,
-    isTextTitle: isCollapsed,
-    children: isCollapsed ? [{ text: noteTitle }] : [],
+    customText: !isCollapsed ? Editor.string(editor, selection) : undefined,
+    children: [],
   };
   wrapLink(editor, link);
 };

--- a/editor/plugins/withAutoMarkdown.ts
+++ b/editor/plugins/withAutoMarkdown.ts
@@ -235,7 +235,6 @@ const withAutoMarkdown = (editor: Editor) => {
           type: ElementType.NoteLink,
           noteId,
           noteTitle,
-          isTextTitle: true,
           children: [],
         };
         Transforms.wrapNodes(editor, link, {

--- a/editor/plugins/withLinks.ts
+++ b/editor/plugins/withLinks.ts
@@ -4,13 +4,17 @@ import { insertExternalLink } from 'editor/formatting';
 import { ElementType } from 'types/slate';
 
 const withLinks = (editor: Editor) => {
-  const { insertData, insertText, isInline } = editor;
+  const { insertData, insertText, isInline, isVoid } = editor;
 
   editor.isInline = (element) => {
     return element.type === ElementType.ExternalLink ||
       element.type === ElementType.NoteLink
       ? true
       : isInline(element);
+  };
+
+  editor.isVoid = (element) => {
+    return element.type === ElementType.NoteLink ? true : isVoid(element);
   };
 
   editor.insertText = (text) => {

--- a/editor/plugins/withNormalization.ts
+++ b/editor/plugins/withNormalization.ts
@@ -2,7 +2,7 @@ import { Editor, Element, Node, Selection, Text, Transforms } from 'slate';
 import { Mark } from 'types/slate';
 
 const withNormalization = (editor: Editor) => {
-  const { normalizeNode, isInline } = editor;
+  const { normalizeNode } = editor;
 
   editor.normalizeNode = (entry) => {
     const [node, path] = entry;
@@ -14,7 +14,8 @@ const withNormalization = (editor: Editor) => {
       for (const [child, childPath] of Node.children(editor, path)) {
         if (
           Element.isElement(child) &&
-          isInline(child) &&
+          editor.isInline(child) &&
+          !editor.isVoid(child) &&
           !Node.string(child)
         ) {
           Transforms.unwrapNodes(editor, { at: childPath });

--- a/editor/serialize.ts
+++ b/editor/serialize.ts
@@ -132,9 +132,9 @@ export default function serialize(
 
     case ElementType.NoteLink: {
       const noteLink = chunk as NoteLink;
-      return noteLink.isTextTitle
-        ? `[[${children}]]`
-        : `[${children}]([[${noteLink.noteTitle}]])`;
+      return noteLink.customText
+        ? `[${noteLink.customText}]([[${noteLink.noteTitle}]])`
+        : `[[${noteLink.noteTitle}]]`;
     }
     case ElementType.ExternalLink:
       return `[${children}](${(chunk as ExternalLink).url || ''})`;

--- a/editor/useBacklinks.ts
+++ b/editor/useBacklinks.ts
@@ -281,13 +281,6 @@ const updateBacklinks = async (newTitle: string, noteId: string) => {
 
         // Update noteTitle property on the node
         linkNode.noteTitle = newTitle;
-
-        // If isTextTitle is true, then the link text should always be equal to the note title
-        if (linkNode.isTextTitle) {
-          for (const linkNodeChild of linkNode.children) {
-            linkNodeChild.text = newTitle;
-          }
-        }
       });
     }
     updateData.push({

--- a/editor/useBacklinks.ts
+++ b/editor/useBacklinks.ts
@@ -281,6 +281,13 @@ const updateBacklinks = async (newTitle: string, noteId: string) => {
 
         // Update noteTitle property on the node
         linkNode.noteTitle = newTitle;
+
+        // If there is no custom text, then the link text should be the same as the note title
+        if (!linkNode.customText) {
+          for (const linkNodeChild of linkNode.children) {
+            linkNodeChild.text = newTitle;
+          }
+        }
       });
     }
     updateData.push({

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -16,7 +16,7 @@
   }
 
   .link {
-    @apply underline cursor-pointer text-primary-600;
+    @apply cursor-pointer text-primary-600 hover:text-primary-800;
   }
 }
 

--- a/types/slate.ts
+++ b/types/slate.ts
@@ -76,8 +76,7 @@ export type NoteLink = {
   type: ElementType.NoteLink;
   noteId: string;
   noteTitle: string;
-  // True when the note link text should always be the same as the note title, false if there is custom text
-  isTextTitle: boolean;
+  customText?: string;
   children: FormattedText[];
 };
 


### PR DESCRIPTION
- update note links to be void elements (noneditable)
- update note link, external link, and code styles

advantages:
- can tell the diff between note links, external links, and inline code
- no more accidentally deleting a character of a note link without meaning to