### PR TITLE
Highlight and scroll to backlink matches when clicked

### DIFF
--- a/components/AppLayout.tsx
+++ b/components/AppLayout.tsx
@@ -52,8 +52,8 @@ export default function AppLayout(props: Props) {
           upsertNote(payload.new);
         } else if (payload.eventType === 'UPDATE') {
           // Don't update the note if it is currently open
-          const openNoteIds = store.getState().openNoteIds;
-          if (!openNoteIds.includes(payload.new.id)) {
+          const openNotes = store.getState().openNotes;
+          if (!openNotes.some((openNote) => openNote.id === payload.new.id)) {
             updateNote(payload.new);
           }
         } else if (payload.eventType === 'DELETE') {

--- a/components/Note.tsx
+++ b/components/Note.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import type { Descendant } from 'slate';
+import type { Descendant, Path } from 'slate';
 import { toast } from 'react-toastify';
 import { useRouter } from 'next/router';
 import Editor from 'components/editor/Editor';
@@ -22,10 +22,11 @@ const UNIQUE_VIOLATION_ERROR_CODE = '23505';
 
 type Props = {
   noteId: string;
+  highlightedPath?: Path;
 };
 
 export default function Note(props: Props) {
-  const { noteId } = props;
+  const { noteId, highlightedPath } = props;
   const router = useRouter();
 
   const note = useStore<NoteType | undefined>(
@@ -204,6 +205,7 @@ export default function Note(props: Props) {
                 className="flex-1 px-12 pt-2 pb-12"
                 value={note.content}
                 setValue={setEditorValue}
+                highlightedPath={highlightedPath}
               />
             </div>
             <Backlinks className="mx-8 mb-12" />

--- a/components/editor/EditorElement.tsx
+++ b/components/editor/EditorElement.tsx
@@ -137,7 +137,10 @@ const NoteLinkElement = (props: NoteLinkElementProps) => {
       {isPageStackingOn ? (
         <span
           className={className}
-          onClick={() => onNoteLinkClick(element.noteId)}
+          onClick={(e) => {
+            e.stopPropagation();
+            onNoteLinkClick(element.noteId);
+          }}
           contentEditable={false}
           {...attributes}
         >
@@ -147,7 +150,12 @@ const NoteLinkElement = (props: NoteLinkElementProps) => {
       ) : (
         <span>
           <Link href={`/app/note/${element.noteId}`}>
-            <a className={className} contentEditable={false} {...attributes}>
+            <a
+              className={className}
+              contentEditable={false}
+              onClick={(e) => e.stopPropagation()}
+              {...attributes}
+            >
               {element.customText ?? element.noteTitle}
               {children}
             </a>
@@ -171,9 +179,11 @@ const ExternalLinkElement = (props: ExternalLinkElementProps) => {
       <a
         className="link"
         href={element.url}
-        onClick={() =>
-          window.open(element.url, '_blank', 'noopener noreferrer')
-        }
+        onClick={(e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          window.open(element.url, '_blank', 'noopener noreferrer');
+        }}
         {...attributes}
       >
         {children}

--- a/components/editor/NoteHeader.tsx
+++ b/components/editor/NoteHeader.tsx
@@ -14,7 +14,8 @@ export default function NoteHeader() {
   const currentNote = useCurrentNote();
 
   const isSidebarButtonVisible = useStore(
-    (state) => !state.isSidebarOpen && state.openNoteIds?.[0] === currentNote.id
+    (state) =>
+      !state.isSidebarOpen && state.openNotes?.[0].id === currentNote.id
   );
   const setIsSidebarOpen = useStore((state) => state.setIsSidebarOpen);
 

--- a/components/editor/backlinks/BacklinkMatchLeaf.tsx
+++ b/components/editor/backlinks/BacklinkMatchLeaf.tsx
@@ -1,16 +1,23 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useMemo } from 'react';
+import { useRouter } from 'next/router';
 import { BacklinkMatch } from 'editor/useBacklinks';
+import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
+import { useStore } from 'lib/store';
 import EditorElement from '../EditorElement';
 import EditorLeaf from '../EditorLeaf';
 import { ReadOnlyEditor } from '../ReadOnlyEditor';
 
 type BacklinkMatchLeafProps = {
+  noteId: string;
   match: BacklinkMatch;
   className?: string;
 };
 
 const BacklinkMatchLeaf = (props: BacklinkMatchLeafProps) => {
-  const { match, className } = props;
+  const { noteId, match, className } = props;
+  const onNoteLinkClick = useOnNoteLinkClick();
+  const isPageStackingOn = useStore((state) => state.isPageStackingOn);
+  const router = useRouter();
 
   const renderElement = useCallback(
     (props) => <EditorElement omitVerticalSpacing={true} {...props} />,
@@ -18,16 +25,31 @@ const BacklinkMatchLeaf = (props: BacklinkMatchLeafProps) => {
   );
   const renderLeaf = useCallback((props) => <EditorLeaf {...props} />, []);
 
-  return (
-    <span
-      className={`block text-xs text-gray-600 bg-gray-50 rounded p-2 my-1 w-full break-words ${className}`}
-    >
+  const backlinkMatch = useMemo(
+    () => (
       <ReadOnlyEditor
         value={[match.lineElement]}
         renderElement={renderElement}
         renderLeaf={renderLeaf}
       />
-    </span>
+    ),
+    [match.lineElement, renderElement, renderLeaf]
+  );
+  const containerClassName = `block text-left text-xs text-gray-600 bg-gray-50 rounded p-2 my-1 w-full break-words ${className}`;
+
+  return (
+    <button
+      className={containerClassName}
+      onClick={() => {
+        if (isPageStackingOn) {
+          onNoteLinkClick(noteId, match.linePath);
+        } else {
+          router.push(`/app/note/${noteId}#${match.linePath}`);
+        }
+      }}
+    >
+      {backlinkMatch}
+    </button>
   );
 };
 

--- a/components/editor/backlinks/Backlinks.tsx
+++ b/components/editor/backlinks/Backlinks.tsx
@@ -83,7 +83,7 @@ const backlinkToTreeData = (isLinked: boolean) => (backlink: Backlink) => {
     labelNode: <BacklinkNoteBranch backlink={backlink} />,
     children: matches.map((match) => ({
       id: `${idPrefix}-${backlink.id}-${match.path.toString()}`,
-      labelNode: <BacklinkMatchLeaf match={match} />,
+      labelNode: <BacklinkMatchLeaf noteId={backlink.id} match={match} />,
       showArrow: false,
     })),
   };

--- a/components/sidebar/SidebarNotes.tsx
+++ b/components/sidebar/SidebarNotes.tsx
@@ -79,7 +79,7 @@ const NoteLinkDropdown = (props: NoteLinkDropdownProps) => {
   const { note, className } = props;
   const router = useRouter();
   const { deleteBacklinks } = useBacklinks(note.id);
-  const openNoteIds = useStore((state) => state.openNoteIds);
+  const openNotes = useStore((state) => state.openNotes);
 
   const containerRef = useRef<HTMLDivElement | null>(null);
   const [popperElement, setPopperElement] = useState<HTMLDivElement | null>(
@@ -95,15 +95,15 @@ const NoteLinkDropdown = (props: NoteLinkDropdownProps) => {
     await deleteNote(note.id);
     await deleteBacklinks();
 
-    const deletedNoteIndex = openNoteIds.findIndex(
-      (openNoteId) => openNoteId === note.id
+    const deletedNoteIndex = openNotes.findIndex(
+      (openNote) => openNote.id === note.id
     );
     if (deletedNoteIndex !== -1) {
       // Redirect if one of the notes that was deleted was open
       const newNoteId = Object.keys(store.getState().notes)[0];
       router.push(`/app/note/${newNoteId}`, undefined, { shallow: true });
     }
-  }, [router, note.id, openNoteIds, deleteBacklinks]);
+  }, [router, note.id, openNotes, deleteBacklinks]);
 
   return (
     <div ref={containerRef}>

--- a/editor/useOnNoteLinkClick.ts
+++ b/editor/useOnNoteLinkClick.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useRouter } from 'next/router';
+import { Path } from 'slate';
 import { useAuth } from 'utils/useAuth';
 import { useCurrentNote } from 'utils/useCurrentNote';
 import { useStore } from 'lib/store';
@@ -9,10 +10,11 @@ export default function useOnNoteLinkClick() {
   const router = useRouter();
   const currentNote = useCurrentNote();
   const openNotes = useStore((state) => state.openNotes);
+  const updateOpenNote = useStore((state) => state.updateOpenNote);
   const setOpenNotes = useStore((state) => state.setOpenNotes);
 
   const onClick = useCallback(
-    (noteId: string) => {
+    (noteId: string, highlightedPath?: Path) => {
       // If the note is already open, scroll it into view
       const openNote = openNotes.find((openNote) => openNote.id === noteId);
       if (openNote) {
@@ -20,6 +22,12 @@ export default function useOnNoteLinkClick() {
           behavior: 'smooth',
           inline: 'center',
         });
+
+        // Update highlighted path
+        if (highlightedPath) {
+          updateOpenNote(openNote.id, { highlightedPath });
+        }
+
         return;
       }
 
@@ -58,9 +66,9 @@ export default function useOnNoteLinkClick() {
       );
 
       // Add note to open notes
-      setOpenNotes([{ id: noteId }], currentNoteIndex + 1);
+      setOpenNotes([{ id: noteId, highlightedPath }], currentNoteIndex + 1);
     },
-    [user, router, currentNote.id, openNotes, setOpenNotes]
+    [user, router, currentNote.id, openNotes, setOpenNotes, updateOpenNote]
   );
 
   return onClick;

--- a/editor/useOnNoteLinkClick.ts
+++ b/editor/useOnNoteLinkClick.ts
@@ -2,32 +2,30 @@ import { useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from 'utils/useAuth';
 import { useCurrentNote } from 'utils/useCurrentNote';
-import { shallowEqual, useStore } from 'lib/store';
+import { useStore } from 'lib/store';
 
 export default function useOnNoteLinkClick() {
   const { user } = useAuth();
   const router = useRouter();
   const currentNote = useCurrentNote();
-  const openNoteIds = useStore((state) => state.openNoteIds, shallowEqual);
-  const setOpenNoteIds = useStore((state) => state.setOpenNoteIds);
+  const openNotes = useStore((state) => state.openNotes);
+  const setOpenNotes = useStore((state) => state.setOpenNotes);
 
   const onClick = useCallback(
     (noteId: string) => {
       // If the note is already open, scroll it into view
-      const openNoteId = openNoteIds.find(
-        (openNoteId) => openNoteId === noteId
-      );
-      if (openNoteId) {
-        document.getElementById(openNoteId)?.scrollIntoView({
+      const openNote = openNotes.find((openNote) => openNote.id === noteId);
+      if (openNote) {
+        document.getElementById(openNote.id)?.scrollIntoView({
           behavior: 'smooth',
           inline: 'center',
         });
         return;
       }
 
-      // If the note is not open, add it to the open note ids
-      const currentNoteIndex = openNoteIds.findIndex(
-        (openNoteId) => openNoteId === currentNote.id
+      // If the note is not open, add it to the open notes
+      const currentNoteIndex = openNotes.findIndex(
+        (openNote) => openNote.id === currentNote.id
       );
       if (currentNoteIndex < 0 || !user) {
         return;
@@ -59,10 +57,10 @@ export default function useOnNoteLinkClick() {
         { shallow: true }
       );
 
-      // Add note to open note ids
-      setOpenNoteIds([noteId], currentNoteIndex + 1);
+      // Add note to open notes
+      setOpenNotes([{ id: noteId }], currentNoteIndex + 1);
     },
-    [user, router, currentNote.id, openNoteIds, setOpenNoteIds]
+    [user, router, currentNote.id, openNotes, setOpenNotes]
   );
 
   return onClick;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -17,7 +17,7 @@ const immer =
 
 export type Notes = Record<Note['id'], Note>;
 
-type OpenNote = {
+export type OpenNote = {
   id: string;
   highlightedPath?: Path;
 };
@@ -29,6 +29,7 @@ export type Store = {
   updateNote: (note: NoteUpdate) => void;
   deleteNote: (noteId: string) => void;
   openNotes: OpenNote[];
+  updateOpenNote: (noteId: string, openNoteUpdate: Partial<OpenNote>) => void;
   setOpenNotes: (openNotes: OpenNote[], index?: number) => void;
   isSidebarOpen: boolean;
   setIsSidebarOpen: (value: boolean | ((value: boolean) => boolean)) => void;
@@ -90,6 +91,21 @@ export const store = createVanilla<Store>(
      * The notes that have their content visible, including the main note and the stacked notes
      */
     openNotes: [],
+    /**
+     * Updates the open note with the specified noteId.
+     */
+    updateOpenNote: (noteId: string, openNoteUpdate: Partial<OpenNote>) => {
+      set((state) => {
+        const index = state.openNotes.findIndex((note) => note.id === noteId);
+        if (index < 0) {
+          return;
+        }
+        state.openNotes[index] = {
+          ...state.openNotes[index],
+          ...openNoteUpdate,
+        };
+      });
+    },
     /**
      * Replaces the open notes at the given index (0 by default)
      */

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -1,8 +1,7 @@
-import create from 'zustand';
+import create, { State, StateCreator } from 'zustand';
 import createVanilla from 'zustand/vanilla';
-import produce from 'immer';
-import type { State, StateCreator } from 'zustand';
-import type { Draft } from 'immer';
+import produce, { Draft } from 'immer';
+import { Path } from 'slate';
 import type { Note } from 'types/supabase';
 import type { NoteUpdate } from './api/updateNote';
 
@@ -18,14 +17,19 @@ const immer =
 
 export type Notes = Record<Note['id'], Note>;
 
+type OpenNote = {
+  id: string;
+  highlightedPath?: Path;
+};
+
 export type Store = {
   notes: Notes;
   setNotes: (value: Notes | ((value: Notes) => Notes)) => void;
   upsertNote: (note: Note) => void;
   updateNote: (note: NoteUpdate) => void;
   deleteNote: (noteId: string) => void;
-  openNoteIds: Note['id'][];
-  setOpenNoteIds: (openNoteIds: Note['id'][], index?: number) => void;
+  openNotes: OpenNote[];
+  setOpenNotes: (openNotes: OpenNote[], index?: number) => void;
   isSidebarOpen: boolean;
   setIsSidebarOpen: (value: boolean | ((value: boolean) => boolean)) => void;
   isPageStackingOn: boolean;
@@ -83,25 +87,25 @@ export const store = createVanilla<Store>(
       });
     },
     /**
-     * The note ids that have their content visible, including the main note and the stacked notes
+     * The notes that have their content visible, including the main note and the stacked notes
      */
-    openNoteIds: [],
+    openNotes: [],
     /**
-     * Replaces the open note ids at the given index (0 by default)
+     * Replaces the open notes at the given index (0 by default)
      */
-    setOpenNoteIds: (newOpenNoteIds: Note['id'][], index?: number) => {
+    setOpenNotes: (newOpenNotes: OpenNote[], index?: number) => {
       if (!index) {
         set((state) => {
-          state.openNoteIds = newOpenNoteIds;
+          state.openNotes = newOpenNotes;
         });
         return;
       }
       // Replace the notes after the current note with the new note
       set((state) => {
-        state.openNoteIds.splice(
+        state.openNotes.splice(
           index,
-          state.openNoteIds.length - index,
-          ...newOpenNoteIds
+          state.openNotes.length - index,
+          ...newOpenNotes
         );
       });
     },


### PR DESCRIPTION
This PR does a few things:
- It refactors `openNoteIds` to be `openNotes`, which contains not just the note id, but also a `highlightedPath` param. This `highlightedPath` param is used in `Editor` to highlight the matching path and scroll to it.
- When a backlink match is clicked, it will add an open note with the proper `highlightedPath`, causing the backlinked note to open, scroll to the proper match, and highlight it.