### PR TITLE
Horizontally center notes

### DIFF
--- a/components/Note.tsx
+++ b/components/Note.tsx
@@ -172,7 +172,7 @@ export default function Note(props: Props) {
   }, [router, isSynced]);
 
   const noteContainerClassName =
-    'flex flex-col flex-shrink-0 w-full bg-white border-r-0 md:border-r md:w-128 lg:w-176';
+    'flex flex-col flex-shrink-0 md:flex-shrink w-full bg-white';
   const errorContainerClassName = `${noteContainerClassName} items-center justify-center h-full`;
 
   if (!note) {
@@ -194,8 +194,8 @@ export default function Note(props: Props) {
       <ProvideCurrentNote value={note}>
         <div id={note.id} className={noteContainerClassName}>
           <NoteHeader />
-          <div className="flex flex-col flex-1 overflow-y-auto">
-            <div className="flex flex-col flex-1">
+          <div className="flex flex-col flex-1 overflow-x-hidden overflow-y-auto">
+            <div className="flex flex-col flex-1 w-full mx-auto md:w-128 lg:w-160 xl:w-192">
               <Title
                 className="px-12 pt-12 pb-1"
                 value={noteTitle}
@@ -207,8 +207,8 @@ export default function Note(props: Props) {
                 setValue={setEditorValue}
                 highlightedPath={highlightedPath}
               />
+              <Backlinks className="mx-8 mb-12" />
             </div>
-            <Backlinks className="mx-8 mb-12" />
           </div>
         </div>
       </ProvideCurrentNote>

--- a/pages/app/note/[id].tsx
+++ b/pages/app/note/[id].tsx
@@ -99,7 +99,7 @@ export default function NotePage(props: Props) {
         <title>{pageTitle}</title>
       </Head>
       <AppLayout initialNotes={initialNotes}>
-        <div className="flex flex-1 overflow-x-auto bg-gray-50">
+        <div className="flex flex-1 overflow-x-auto divide-x">
           {openNoteIds.length > 0
             ? openNoteIds.map((noteId, index) => (
                 <Note

--- a/pages/changelog.tsx
+++ b/pages/changelog.tsx
@@ -13,7 +13,7 @@ export default function Changelog() {
         <h1 className="text-4xl font-medium text-center md:text-5xl">
           Changelog
         </h1>
-        <p className="pt-6">
+        <p className="pt-8">
           This page lists when major features and bug fixes are added to
           Notabase. Note that Notabase is constantly being updated and this page
           may not be comprehensive. For a full list of technical changes, go to{' '}
@@ -27,7 +27,13 @@ export default function Changelog() {
           </a>
           .
         </p>
-        <div className="pt-4 divide-y md:pt-8">
+        <div className="divide-y">
+          <ChangelogBlock
+            title="July 7, 2021"
+            features={[
+              'Horizontally center notes for a more ergonomic experience',
+            ]}
+          />
           <ChangelogBlock
             title="July 5, 2021"
             bugFixes={[
@@ -77,7 +83,7 @@ type ChangelogBlockProps = {
 const ChangelogBlock = (props: ChangelogBlockProps) => {
   const { title, features, bugFixes } = props;
   return (
-    <div className="py-4 md:py-8">
+    <div className="py-8">
       <h2 className="text-2xl font-medium md:text-3xl">{title}</h2>
       {features && features.length > 0 ? (
         <>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 const colors = require('tailwindcss/colors');
-const defaultTheme = require('tailwindcss/defaultTheme');
 
 module.exports = {
   mode: 'jit',
@@ -10,25 +9,23 @@ module.exports = {
     container: {
       center: true,
     },
-    spacing: {
-      ...defaultTheme.spacing,
-      0.25: '0.0625rem',
-      128: '32rem',
-      176: '44rem',
-      'screen-10': '10vh',
-      'screen-80': '80vh',
-    },
-    colors: {
-      ...colors,
-      primary: colors.emerald,
-      gray: colors.trueGray,
-    },
-    boxShadow: {
-      ...defaultTheme.boxShadow,
-      popover:
-        'rgb(15 15 15 / 10%) 0px 3px 6px, rgb(15 15 15 / 20%) 0px 9px 24px',
-    },
     extend: {
+      spacing: {
+        0.25: '0.0625rem',
+        128: '32rem',
+        160: '40rem',
+        192: '48rem',
+        'screen-10': '10vh',
+        'screen-80': '80vh',
+      },
+      colors: {
+        primary: colors.emerald,
+        gray: colors.trueGray,
+      },
+      boxShadow: {
+        popover:
+          'rgb(15 15 15 / 10%) 0px 3px 6px, rgb(15 15 15 / 20%) 0px 9px 24px',
+      },
       typography: {
         DEFAULT: {
           css: {


### PR DESCRIPTION
This PR horizontally centers notes in order to provide a more ergonomic experience while editing/reading, while still preserving page stacking.

It also slightly adjusts the maximum width of the editor. On `lg` devices it is now slightly smaller, while on `xl` devices it is now slightly bigger.

The Tailwind config has also been refactored so that new styles are now put inside `extend` (which removes the need to manually put in the default styles).