### PR TITLE
Add note sorting

### DIFF
--- a/components/editor/NoteHeader.tsx
+++ b/components/editor/NoteHeader.tsx
@@ -69,7 +69,7 @@ export default function NoteHeader() {
               <Portal>
                 <Menu.Items
                   ref={setPopperElement}
-                  className="z-10 bg-white rounded shadow-popover"
+                  className="z-10 overflow-hidden bg-white rounded shadow-popover"
                   static
                   style={styles.popper}
                   {...attributes.popper}

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -42,7 +42,7 @@ export default function Sidebar(props: Props) {
           onClick={() => setIsFindOrCreateModalOpen((isOpen) => !isOpen)}
         >
           <IconSearch className="mr-1 text-gray-800" size={20} />
-          <span>Find or create note</span>
+          <span>Find or Create Note</span>
         </button>
       </SidebarItem>
       <SidebarItem isHighlighted={router.pathname.includes('/app/graph')}>
@@ -56,6 +56,7 @@ export default function Sidebar(props: Props) {
       <SidebarContent
         className="flex-1 mt-3 overflow-x-hidden overflow-y-auto"
         currentNoteId={currentNoteId}
+        setIsFindOrCreateModalOpen={setIsFindOrCreateModalOpen}
       />
     </div>
   );

--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -79,7 +79,7 @@ const Header = () => {
             <IconChevronsLeft className="text-gray-500" />
           </span>
         </Menu.Button>
-        <Menu.Items className="absolute z-10 w-56 bg-white rounded left-6 top-full shadow-popover">
+        <Menu.Items className="absolute z-10 w-56 overflow-hidden bg-white rounded left-6 top-full shadow-popover">
           <p className="px-4 py-2 overflow-hidden text-xs text-gray-600 overflow-ellipsis">
             {user?.email}
           </p>

--- a/components/sidebar/SidebarContent.tsx
+++ b/components/sidebar/SidebarContent.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import { IconFile, IconSearch } from '@tabler/icons';
 import SidebarNotes from './SidebarNotes';
 import SidebarSearch from './SidebarSearch';
@@ -11,10 +11,11 @@ enum SidebarTab {
 type Props = {
   currentNoteId?: string;
   className?: string;
+  setIsFindOrCreateModalOpen: Dispatch<SetStateAction<boolean>>;
 };
 
 export default function SidebarContent(props: Props) {
-  const { currentNoteId, className } = props;
+  const { currentNoteId, className, setIsFindOrCreateModalOpen } = props;
   const [activeTab, setActiveTab] = useState<SidebarTab>(SidebarTab.Notes);
 
   return (
@@ -24,6 +25,7 @@ export default function SidebarContent(props: Props) {
         <SidebarNotes
           className={activeTab !== SidebarTab.Notes ? 'hidden' : undefined}
           currentNoteId={currentNoteId}
+          setIsFindOrCreateModalOpen={setIsFindOrCreateModalOpen}
         />
         <SidebarSearch
           className={activeTab !== SidebarTab.Search ? 'hidden' : undefined}

--- a/components/sidebar/SidebarContent.tsx
+++ b/components/sidebar/SidebarContent.tsx
@@ -20,7 +20,7 @@ export default function SidebarContent(props: Props) {
   return (
     <div className={`flex flex-col ${className}`}>
       <Tabs activeTab={activeTab} setActiveTab={setActiveTab} />
-      <div className="flex flex-col flex-1 overflow-x-hidden overflow-y-auto">
+      <div className="flex flex-col flex-1 overflow-x-hidden">
         <SidebarNotes
           className={activeTab !== SidebarTab.Notes ? 'hidden' : undefined}
           currentNoteId={currentNoteId}

--- a/components/sidebar/SidebarNotes.tsx
+++ b/components/sidebar/SidebarNotes.tsx
@@ -44,7 +44,7 @@ export default function SidebarNotes(props: SidebarNotesProps) {
   const sortedNotes = useMemo(
     () =>
       notes.sort((n1, n2) => {
-        if (noteSort === Sort.NameDescending) {
+        if (noteSort === Sort.TitleDescending) {
           return caseInsensitiveStringCompare(n2.title, n1.title);
         } else {
           return caseInsensitiveStringCompare(n1.title, n2.title);

--- a/components/sidebar/SidebarNotes.tsx
+++ b/components/sidebar/SidebarNotes.tsx
@@ -96,10 +96,10 @@ const SortDropdown = (props: SortDropdownProps) => {
   return (
     <Menu>
       <Menu.Button
-        className="p-1 m-1 rounded hover:bg-gray-200 active:bg-gray-300"
+        className="p-1 m-1 mr-5 rounded hover:bg-gray-200 active:bg-gray-300"
         ref={buttonRef}
       >
-        <IconSortDescending size={16} className="text-gray-800" />
+        <IconSortDescending size={16} className="text-gray-600" />
       </Menu.Button>
       <Menu.Items
         className="z-10 w-56 overflow-hidden bg-white rounded shadow-popover"

--- a/components/sidebar/SidebarNotes.tsx
+++ b/components/sidebar/SidebarNotes.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import {
+  Dispatch,
+  SetStateAction,
+  useCallback,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Menu } from '@headlessui/react';
@@ -7,6 +14,7 @@ import {
   IconDots,
   IconTrash,
   IconCheck,
+  IconPlus,
 } from '@tabler/icons';
 import { usePopper } from 'react-popper';
 import type { Note } from 'types/supabase';
@@ -22,10 +30,11 @@ import SidebarItem from './SidebarItem';
 type SidebarNotesProps = {
   currentNoteId?: string;
   className?: string;
+  setIsFindOrCreateModalOpen: Dispatch<SetStateAction<boolean>>;
 };
 
 export default function SidebarNotes(props: SidebarNotesProps) {
-  const { currentNoteId, className } = props;
+  const { currentNoteId, className, setIsFindOrCreateModalOpen } = props;
 
   const notes = useStore(
     (state) =>
@@ -56,9 +65,6 @@ export default function SidebarNotes(props: SidebarNotesProps) {
   return (
     <ErrorBoundary>
       <div className={`flex flex-col flex-1 overflow-x-hidden ${className}`}>
-        <div className="flex items-center justify-end">
-          <SortDropdown currentSort={noteSort} setCurrentSort={setNoteSort} />
-        </div>
         <div className="overflow-y-auto">
           {sortedNotes && sortedNotes.length > 0 ? (
             sortedNotes.map((note) => (
@@ -71,6 +77,18 @@ export default function SidebarNotes(props: SidebarNotesProps) {
           ) : (
             <p className="px-6 my-2 text-gray-500">No notes yet</p>
           )}
+        </div>
+        <div className="flex items-center justify-between border-t">
+          <button
+            className="p-1 mx-2 my-1 rounded hover:bg-gray-200 active:bg-gray-300"
+            onClick={() => setIsFindOrCreateModalOpen((isOpen) => !isOpen)}
+          >
+            <IconPlus size={16} className="text-gray-600" />
+          </button>
+          <span className="p-1 mx-2 my-1 text-xs text-gray-500">
+            {notes.length} notes
+          </span>
+          <SortDropdown currentSort={noteSort} setCurrentSort={setNoteSort} />
         </div>
       </div>
     </ErrorBoundary>
@@ -96,7 +114,7 @@ const SortDropdown = (props: SortDropdownProps) => {
   return (
     <Menu>
       <Menu.Button
-        className="p-1 m-1 mr-5 rounded hover:bg-gray-200 active:bg-gray-300"
+        className="p-1 mx-2 my-1 rounded hover:bg-gray-200 active:bg-gray-300"
         ref={buttonRef}
       >
         <IconSortDescending size={16} className="text-gray-600" />

--- a/components/sidebar/SidebarNotes.tsx
+++ b/components/sidebar/SidebarNotes.tsx
@@ -65,7 +65,7 @@ export default function SidebarNotes(props: SidebarNotesProps) {
   return (
     <ErrorBoundary>
       <div className={`flex flex-col flex-1 overflow-x-hidden ${className}`}>
-        <div className="overflow-y-auto">
+        <div className="flex-1 overflow-y-auto">
           {sortedNotes && sortedNotes.length > 0 ? (
             sortedNotes.map((note) => (
               <NoteLink
@@ -75,7 +75,7 @@ export default function SidebarNotes(props: SidebarNotesProps) {
               />
             ))
           ) : (
-            <p className="px-6 my-2 text-gray-500">No notes yet</p>
+            <p className="px-6 my-2 text-center text-gray-500">No notes yet</p>
           )}
         </div>
         <div className="flex items-center justify-between border-t">

--- a/constants/userSettings.ts
+++ b/constants/userSettings.ts
@@ -1,0 +1,13 @@
+export enum Sort {
+  NameAscending = 'NAME_ASCENDING',
+  NameDescending = 'NAME_DESCENDING',
+}
+
+export const ReadableNameBySort = {
+  [Sort.NameAscending]: 'Sort by name (A-Z)',
+  [Sort.NameDescending]: 'Sort by name (Z-A)',
+} as const;
+
+export type UserSettings = {
+  noteSort: Sort;
+};

--- a/constants/userSettings.ts
+++ b/constants/userSettings.ts
@@ -1,11 +1,11 @@
 export enum Sort {
-  NameAscending = 'NAME_ASCENDING',
-  NameDescending = 'NAME_DESCENDING',
+  TitleAscending = 'TITLE_ASCENDING',
+  TitleDescending = 'TITLE_DESCENDING',
 }
 
 export const ReadableNameBySort = {
-  [Sort.NameAscending]: 'Sort by name (A-Z)',
-  [Sort.NameDescending]: 'Sort by name (Z-A)',
+  [Sort.TitleAscending]: 'Sort by title (A-Z)',
+  [Sort.TitleDescending]: 'Sort by title (Z-A)',
 } as const;
 
 export type UserSettings = {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -2,6 +2,7 @@ import create, { State, StateCreator } from 'zustand';
 import createVanilla from 'zustand/vanilla';
 import produce, { Draft } from 'immer';
 import type { Note } from 'types/supabase';
+import { Sort, UserSettings } from 'constants/userSettings';
 import type { NoteUpdate } from './api/updateNote';
 
 export { default as shallowEqual } from 'zustand/shallow';
@@ -28,6 +29,10 @@ export type Store = {
   setIsSidebarOpen: (value: boolean | ((value: boolean) => boolean)) => void;
   isPageStackingOn: boolean;
   setIsPageStackingOn: (value: boolean | ((value: boolean) => boolean)) => void;
+  userSettings: UserSettings;
+  updateUserSettingByKey: (
+    key: keyof UserSettings
+  ) => (value: UserSettings[typeof key]) => void;
 };
 
 export const store = createVanilla<Store>(
@@ -127,6 +132,15 @@ export const store = createVanilla<Store>(
         });
       }
     },
+    userSettings: {
+      noteSort: Sort.NameAscending,
+    },
+    updateUserSettingByKey:
+      (key: keyof UserSettings) => (value: UserSettings[typeof key]) => {
+        set((state) => {
+          state.userSettings[key] = value;
+        });
+      },
   }))
 );
 

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -133,7 +133,7 @@ export const store = createVanilla<Store>(
       }
     },
     userSettings: {
-      noteSort: Sort.NameAscending,
+      noteSort: Sort.TitleAscending,
     },
     updateUserSettingByKey:
       (key: keyof UserSettings) => (value: UserSettings[typeof key]) => {

--- a/pages/changelog.tsx
+++ b/pages/changelog.tsx
@@ -29,6 +29,12 @@ export default function Changelog() {
         </p>
         <div className="divide-y">
           <ChangelogBlock
+            title="July 8, 2021"
+            features={[
+              'Add the option to sort notes by ascending or descending order',
+            ]}
+          />
+          <ChangelogBlock
             title="July 7, 2021"
             features={[
               'Horizontally center notes for a more ergonomic experience',

--- a/utils/string.ts
+++ b/utils/string.ts
@@ -1,5 +1,8 @@
 export function caseInsensitiveStringCompare(str1: string, str2: string) {
-  return str1.localeCompare(str2, undefined, { sensitivity: 'base' });
+  return str1.localeCompare(str2, undefined, {
+    sensitivity: 'base',
+    numeric: true,
+  });
 }
 
 export function caseInsensitiveStringEqual(str1: string, str2: string) {


### PR DESCRIPTION
This PR adds the ability to sort notes by either ascending or descending order (by name). The string compare function has also been modified to turn on numeric sorting.

It also fixes a slight UI bug where dropdown items that are hovered over lose their rounded border.