### PR TITLE
Use client side auth

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,2 @@
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_KEY=your-anon-key
-SUPABASE_SERVICE_KEY=your-service-role-key

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ https://user-images.githubusercontent.com/4218237/122793125-b08a7980-d26f-11eb-8
 
 ## Status
 
-Notabase is currently in alpha. It is under active development.
+Notabase is in alpha. It is under active development.
 
 ## Features
 
@@ -30,7 +30,7 @@ Notabase is currently in alpha. It is under active development.
 Notabase is currently focused on the hosted experience, but it is possible for you to self-host it as well. Here's a list of steps that you need to take to get it running locally (not tested):
 
 1. Notabase uses Supabase as the backend (for authentication and the database), so you'll have to make a [Supabase](https://supabase.io) account. If you prefer to self-host Supabase as well, you can follow the instructions in their [docs](https://supabase.io/docs/guides/self-hosting).
-2. Copy `.env.local.example` into `.env.local` and fill in the environment variables from your [Supabase dashboard](https://app.supabase.io). Go to `Settings` and click on `API`. `NEXT_PUBLIC_SUPABASE_URL` is the `Config URL`, `NEXT_PUBLIC_SUPABASE_KEY` is the public `anon` key, and `SUPABASE_SERVICE_KEY` is the secret `service_role` key.
+2. Copy `.env.local.example` into `.env.local` and fill in the environment variables from your [Supabase dashboard](https://app.supabase.io). Go to `Settings` and click on `API`. `NEXT_PUBLIC_SUPABASE_URL` is the `Config URL` and `NEXT_PUBLIC_SUPABASE_KEY` is the public `anon` key.
 3. Go to the Table Editor on the Supabase dashboard and create two new tables: `users` and `notes`. `users` requires a `id` column with type `uuid`. `notes` requires a `id` column with type `uuid`, a `user_id` column that is a foreign key for the `users` `id` column, a `title` column with type `text`, and a `content` column with type `jsonb`.
 4. You'll want to create a stored procedure that creates a new user in the `users` table whenever a new user is created through Supabase authentication. Go to the SQL tab on the Supabase dashboard and create a new query. Paste the following inside:
 

--- a/components/AppLayout.tsx
+++ b/components/AppLayout.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ReactNode } from 'react';
-import type { Notes } from 'lib/store';
+import { useRouter } from 'next/router';
 import { useStore, store } from 'lib/store';
 import supabase from 'lib/supabase';
 import type { Note } from 'types/supabase';
@@ -13,31 +13,73 @@ const SM_BREAKPOINT = 640;
 
 type Props = {
   children: ReactNode;
-  initialNotes: Notes;
   className?: string;
 };
 
 export default function AppLayout(props: Props) {
-  const { children, initialNotes, className } = props;
-  const { user } = useAuth();
+  const { children, className } = props;
+  const { user, isLoaded } = useAuth();
+  const router = useRouter();
+
+  const [isPageLoaded, setIsPageLoaded] = useState(false);
+  const setNotes = useStore((state) => state.setNotes);
+  const initData = useCallback(async () => {
+    if (!user) {
+      return;
+    }
+
+    const { data: notes } = await supabase
+      .from<Note>('notes')
+      .select('id, title, content')
+      .eq('user_id', user.id)
+      .order('title');
+
+    // Redirect to first note if one exists
+    // TODO: maybe we should redirect to the most recent note instead?
+    if (router.pathname === '/app' && notes && notes.length > 0) {
+      router.replace(`/app/note/${notes[0].id}`);
+      return;
+    }
+
+    if (!notes) {
+      setIsPageLoaded(true);
+      return;
+    }
+
+    const notesAsObj = notes.reduce<Record<Note['id'], Note>>((acc, note) => {
+      acc[note.id] = note;
+      return acc;
+    }, {});
+
+    setNotes(notesAsObj);
+    setIsPageLoaded(true);
+  }, [user, router, setNotes]);
+
+  useEffect(() => {
+    if (isLoaded && !user) {
+      // Redirect to login page if there is no user logged in
+      router.replace('/login');
+    } else if (!isPageLoaded && isLoaded && user) {
+      // Initialize data if there is a user and the data has not been initialized yet
+      initData();
+    }
+  }, [router, user, isLoaded, isPageLoaded, initData]);
+
   const [isFindOrCreateModalOpen, setIsFindOrCreateModalOpen] = useState(false);
 
   const isSidebarOpen = useStore((state) => state.isSidebarOpen);
   const setIsSidebarOpen = useStore((state) => state.setIsSidebarOpen);
   const setIsPageStackingOn = useStore((state) => state.setIsPageStackingOn);
-  const setNotes = useStore((state) => state.setNotes);
   const upsertNote = useStore((state) => state.upsertNote);
   const updateNote = useStore((state) => state.updateNote);
   const deleteNote = useStore((state) => state.deleteNote);
 
   useEffect(() => {
-    setNotes(initialNotes);
-
     if (window.innerWidth <= SM_BREAKPOINT) {
       setIsSidebarOpen(false);
       setIsPageStackingOn(false);
     }
-  }, [initialNotes, setNotes, setIsSidebarOpen, setIsPageStackingOn]);
+  }, [setIsSidebarOpen, setIsPageStackingOn]);
 
   useEffect(() => {
     if (!user) {
@@ -77,6 +119,10 @@ export default function AppLayout(props: Props) {
     [setIsFindOrCreateModalOpen]
   );
   useHotkeys(hotkeys);
+
+  if (!isPageLoaded) {
+    return <div>Loading...</div>;
+  }
 
   return (
     <div className={`flex h-screen ${className}`}>

--- a/components/AppLayout.tsx
+++ b/components/AppLayout.tsx
@@ -8,6 +8,7 @@ import { useAuth } from 'utils/useAuth';
 import useHotkeys from 'utils/useHotkeys';
 import Sidebar from './sidebar/Sidebar';
 import FindOrCreateModal from './FindOrCreateModal';
+import PageLoading from './PageLoading';
 
 const SM_BREAKPOINT = 640;
 
@@ -121,7 +122,7 @@ export default function AppLayout(props: Props) {
   useHotkeys(hotkeys);
 
   if (!isPageLoaded) {
-    return <div>Loading...</div>;
+    return <PageLoading />;
   }
 
   return (

--- a/components/Logo.tsx
+++ b/components/Logo.tsx
@@ -1,0 +1,12 @@
+import Image from 'next/image';
+import logo from 'public/logo.svg';
+
+type Props = {
+  width: number;
+  height: number;
+};
+
+export default function Logo(props: Props) {
+  const { width, height } = props;
+  return <Image src={logo} width={width} height={height} alt="Notabase logo" />;
+}

--- a/components/PageLoading.tsx
+++ b/components/PageLoading.tsx
@@ -1,0 +1,11 @@
+import Spinner from './Spinner';
+import Logo from './Logo';
+
+export default function PageLoading() {
+  return (
+    <div className="flex flex-col items-center justify-center w-screen h-screen space-y-4">
+      <Logo width={128} height={128} />
+      <Spinner />
+    </div>
+  );
+}

--- a/components/landing/Footer.tsx
+++ b/components/landing/Footer.tsx
@@ -1,6 +1,5 @@
 import Link from 'next/link';
-import Image from 'next/image';
-import logo from 'public/logo.svg';
+import Logo from 'components/Logo';
 
 type Props = {
   className?: string;
@@ -14,7 +13,7 @@ export default function Footer(props: Props) {
         <div>
           <Link href="/">
             <a className="flex items-center">
-              <Image src={logo} width={28} height={28} alt="Notabase logo" />
+              <Logo width={28} height={28} />
               <span className="ml-2 text-xl font-semibold">Notabase</span>
             </a>
           </Link>

--- a/components/landing/Navbar.tsx
+++ b/components/landing/Navbar.tsx
@@ -1,13 +1,12 @@
 import Link from 'next/link';
-import Image from 'next/image';
-import logo from 'public/logo.svg';
+import Logo from 'components/Logo';
 
 export default function Navbar() {
   return (
     <div className="container flex items-center justify-between px-6 py-6 space-x-6 text-gray-900">
       <Link href="/">
         <a className="flex items-center">
-          <Image src={logo} width={28} height={28} alt="Notabase logo" />
+          <Logo width={28} height={28} />
           <span className="ml-2 text-xl font-semibold">Notabase</span>
         </a>
       </Link>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,6 +4,7 @@ import { ToastContainer } from 'react-toastify';
 import NProgress from 'nprogress';
 import type { AppProps } from 'next/app';
 import { ProvideAuth } from 'utils/useAuth';
+import AppLayout from 'components/AppLayout';
 import 'styles/styles.css';
 import 'styles/nprogress.css';
 import 'react-toastify/dist/ReactToastify.css';
@@ -13,7 +14,7 @@ Router.events.on('routeChangeStart', () => NProgress.start());
 Router.events.on('routeChangeComplete', () => NProgress.done());
 Router.events.on('routeChangeError', () => NProgress.done());
 
-export default function MyApp({ Component, pageProps }: AppProps) {
+export default function MyApp({ Component, pageProps, router }: AppProps) {
   return (
     <>
       <Head>
@@ -47,7 +48,13 @@ export default function MyApp({ Component, pageProps }: AppProps) {
         ></script>
       </Head>
       <ProvideAuth>
-        <Component {...pageProps} />
+        {router.pathname.startsWith('/app') ? (
+          <AppLayout>
+            <Component {...pageProps} />
+          </AppLayout>
+        ) : (
+          <Component {...pageProps} />
+        )}
       </ProvideAuth>
       <ToastContainer
         position="top-center"

--- a/pages/api/auth.ts
+++ b/pages/api/auth.ts
@@ -1,6 +1,0 @@
-import type { NextApiRequest, NextApiResponse } from 'next';
-import supabase from 'lib/supabase';
-
-export default function handler(req: NextApiRequest, res: NextApiResponse) {
-  supabase.auth.api.setAuthCookie(req, res);
-}

--- a/pages/app/graph.tsx
+++ b/pages/app/graph.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useMemo } from 'react';
 import Head from 'next/head';
 import { createEditor, Editor, Element, Node } from 'slate';
 import AppLayout from 'components/AppLayout';
@@ -12,40 +12,6 @@ import ErrorBoundary from 'components/ErrorBoundary';
 
 export default function Graph() {
   const notes = useStore((state) => state.notes, deepEqual);
-
-  // Set graph dimensions
-  const resizeObserverRef = useRef<ResizeObserver | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const [dimensions, setDimensions] = useState({ width: 0, height: 0 });
-
-  const containerRefCallback = useCallback((node: HTMLDivElement | null) => {
-    if (containerRef.current) {
-      resizeObserverRef.current?.unobserve(containerRef.current);
-      containerRef.current = null;
-    }
-
-    if (node) {
-      resizeObserverRef.current?.observe(node);
-      containerRef.current = node;
-    }
-  }, []);
-
-  useEffect(() => {
-    // Initialize resize observer
-    if (!resizeObserverRef.current) {
-      resizeObserverRef.current = new ResizeObserver((entries) => {
-        for (const entry of entries) {
-          const cr = entry.contentRect;
-          setDimensions({ width: cr.width, height: cr.height });
-        }
-      });
-    }
-
-    // Make sure that the resize observer is cleaned up when component is unmounted
-    return () => {
-      resizeObserverRef.current?.disconnect();
-    };
-  }, []);
 
   // Compute graph data
   const graphData: GraphData = useMemo(() => {
@@ -89,14 +55,9 @@ export default function Graph() {
       </Head>
       <AppLayout className="max-w-screen">
         <ErrorBoundary>
-          <div ref={containerRefCallback} className="flex-1">
+          <div className="flex flex-1">
             <GraphHeader />
-            <ForceGraph
-              data={graphData}
-              width={dimensions.width}
-              height={dimensions.height}
-              className="absolute"
-            />
+            <ForceGraph data={graphData} className="flex-1" />
           </div>
         </ErrorBoundary>
       </AppLayout>

--- a/pages/app/graph.tsx
+++ b/pages/app/graph.tsx
@@ -1,7 +1,6 @@
 import { useMemo } from 'react';
 import Head from 'next/head';
 import { createEditor, Editor, Element, Node } from 'slate';
-import AppLayout from 'components/AppLayout';
 import type { NoteLink } from 'types/slate';
 import { ElementType } from 'types/slate';
 import type { GraphData } from 'components/ForceGraph';
@@ -53,14 +52,12 @@ export default function Graph() {
       <Head>
         <title>Graph View | Notabase</title>
       </Head>
-      <AppLayout className="max-w-screen">
-        <ErrorBoundary>
-          <div className="flex flex-1">
-            <GraphHeader />
-            <ForceGraph data={graphData} className="flex-1" />
-          </div>
-        </ErrorBoundary>
-      </AppLayout>
+      <ErrorBoundary>
+        <div className="flex flex-1">
+          <GraphHeader />
+          <ForceGraph data={graphData} className="flex-1" />
+        </div>
+      </ErrorBoundary>
     </>
   );
 }

--- a/pages/app/graph.tsx
+++ b/pages/app/graph.tsx
@@ -1,25 +1,16 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
-import type { GetServerSideProps } from 'next';
 import Head from 'next/head';
 import { createEditor, Editor, Element, Node } from 'slate';
-import { createClient } from '@supabase/supabase-js';
-import type { Note } from 'types/supabase';
 import AppLayout from 'components/AppLayout';
 import type { NoteLink } from 'types/slate';
 import { ElementType } from 'types/slate';
 import type { GraphData } from 'components/ForceGraph';
 import ForceGraph from 'components/ForceGraph';
 import GraphHeader from 'components/GraphHeader';
-import type { Notes } from 'lib/store';
 import { useStore, deepEqual } from 'lib/store';
 import ErrorBoundary from 'components/ErrorBoundary';
 
-type Props = {
-  initialNotes: Notes;
-};
-
-export default function Graph(props: Props) {
-  const { initialNotes } = props;
+export default function Graph() {
   const notes = useStore((state) => state.notes, deepEqual);
 
   // Set graph dimensions
@@ -80,7 +71,7 @@ export default function Graph(props: Props) {
       <Head>
         <title>Graph View | Notabase</title>
       </Head>
-      <AppLayout initialNotes={initialNotes} className="max-w-screen">
+      <AppLayout className="max-w-screen">
         <ErrorBoundary>
           <div ref={containerRef} className="flex-1">
             <GraphHeader />
@@ -96,39 +87,6 @@ export default function Graph(props: Props) {
     </>
   );
 }
-
-export const getServerSideProps: GetServerSideProps<Props> = async ({
-  req,
-}) => {
-  // Create admin supabase client on server
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',
-    process.env.SUPABASE_SERVICE_KEY ?? ''
-  );
-
-  // Get authed user
-  const { user } = await supabase.auth.api.getUserByCookie(req);
-  if (!user) {
-    return { props: {}, redirect: { destination: '/login', permanent: false } };
-  }
-
-  // Get notes from database
-  const { data: notes } = await supabase
-    .from<Note>('notes')
-    .select('id, title, content')
-    .eq('user_id', user.id)
-    .order('title');
-
-  return {
-    props: {
-      initialNotes:
-        notes?.reduce<Record<Note['id'], Note>>((acc, note) => {
-          acc[note.id] = note;
-          return acc;
-        }, {}) ?? {},
-    },
-  };
-};
 
 const getRadius = (numOfLinks: number) => {
   const BASE_RADIUS = 3;

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -1,22 +1,13 @@
-import type { GetServerSideProps } from 'next';
 import Head from 'next/head';
-import { createClient } from '@supabase/supabase-js';
-import type { Note } from 'types/supabase';
 import AppLayout from 'components/AppLayout';
-import type { Notes } from 'lib/store';
 
-type Props = {
-  initialNotes: Notes;
-};
-
-export default function AppHome(props: Props) {
-  const { initialNotes } = props;
+export default function AppHome() {
   return (
     <>
       <Head>
         <title>Notabase</title>
       </Head>
-      <AppLayout initialNotes={initialNotes}>
+      <AppLayout>
         <div className="flex items-center justify-center w-full p-12">
           <p className="text-gray-500">Get started by adding a new note</p>
         </div>
@@ -24,45 +15,3 @@ export default function AppHome(props: Props) {
     </>
   );
 }
-
-export const getServerSideProps: GetServerSideProps<Props> = async ({
-  req,
-}) => {
-  // Create admin supabase client on server
-  const supabase = createClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',
-    process.env.SUPABASE_SERVICE_KEY ?? ''
-  );
-
-  // Get authed user
-  const { user } = await supabase.auth.api.getUserByCookie(req);
-  if (!user) {
-    return { props: {}, redirect: { destination: '/login', permanent: false } };
-  }
-
-  // Get notes from database
-  const { data: notes } = await supabase
-    .from<Note>('notes')
-    .select('id, title, content')
-    .eq('user_id', user.id)
-    .order('title');
-
-  // Redirect to first note if one exists
-  // TODO: maybe we should redirect to the most recent note instead?
-  if (notes && notes.length > 0) {
-    return {
-      props: {},
-      redirect: { destination: `/app/note/${notes[0].id}`, permanent: false },
-    };
-  }
-
-  return {
-    props: {
-      initialNotes:
-        notes?.reduce<Record<Note['id'], Note>>((acc, note) => {
-          acc[note.id] = note;
-          return acc;
-        }, {}) ?? {},
-    },
-  };
-};

--- a/pages/app/index.tsx
+++ b/pages/app/index.tsx
@@ -1,5 +1,4 @@
 import Head from 'next/head';
-import AppLayout from 'components/AppLayout';
 
 export default function AppHome() {
   return (
@@ -7,11 +6,9 @@ export default function AppHome() {
       <Head>
         <title>Notabase</title>
       </Head>
-      <AppLayout>
-        <div className="flex items-center justify-center w-full p-12">
-          <p className="text-gray-500">Get started by adding a new note</p>
-        </div>
-      </AppLayout>
+      <div className="flex items-center justify-center flex-1 w-full p-12">
+        <p className="text-gray-500">Get started by adding a new note</p>
+      </div>
     </>
   );
 }

--- a/pages/app/note/[id].tsx
+++ b/pages/app/note/[id].tsx
@@ -3,7 +3,6 @@ import Head from 'next/head';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { Path } from 'slate';
-import AppLayout from 'components/AppLayout';
 import Note from 'components/Note';
 import { useStore } from 'lib/store';
 import usePrevious from 'utils/usePrevious';
@@ -90,24 +89,22 @@ export default function NotePage() {
       <Head>
         <title>{pageTitle}</title>
       </Head>
-      <AppLayout>
-        <div className="flex flex-1 overflow-x-auto divide-x">
-          {openNoteIds.length > 0
-            ? openNoteIds.map((noteId, index) => (
-                <Note
-                  key={noteId}
-                  noteId={noteId}
-                  className="sticky left-0"
-                  highlightedPath={
-                    highlightedPath?.index === index
-                      ? highlightedPath.path
-                      : undefined
-                  }
-                />
-              ))
-            : null}
-        </div>
-      </AppLayout>
+      <div className="flex flex-1 overflow-x-auto divide-x">
+        {openNoteIds.length > 0
+          ? openNoteIds.map((noteId, index) => (
+              <Note
+                key={noteId}
+                noteId={noteId}
+                className="sticky left-0"
+                highlightedPath={
+                  highlightedPath?.index === index
+                    ? highlightedPath.path
+                    : undefined
+                }
+              />
+            ))
+          : null}
+      </div>
     </>
   );
 }

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -1,10 +1,27 @@
-import type { GetServerSideProps } from 'next';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
-import { createClient } from '@supabase/supabase-js';
 import AuthForm from 'components/AuthForm';
+import { useAuth } from 'utils/useAuth';
 
 export default function Login() {
+  const { user, isLoaded } = useAuth();
+  const [isPageLoaded, setIsPageLoaded] = useState(false);
+  const router = useRouter();
+
+  useEffect(() => {
+    if (isLoaded && user) {
+      router.replace('/app');
+    } else if (isLoaded) {
+      setIsPageLoaded(true);
+    }
+  }, [router, user, isLoaded]);
+
+  if (!isPageLoaded) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <>
       <Head>
@@ -27,20 +44,3 @@ export default function Login() {
     </>
   );
 }
-
-export const getServerSideProps: GetServerSideProps<Record<string, never>> =
-  async ({ req }) => {
-    // Create admin supabase client on server
-    const supabase = createClient(
-      process.env.NEXT_PUBLIC_SUPABASE_URL ?? '',
-      process.env.SUPABASE_SERVICE_KEY ?? ''
-    );
-
-    // Get authed user
-    const { user } = await supabase.auth.api.getUserByCookie(req);
-    if (user) {
-      return { props: {}, redirect: { destination: '/app', permanent: false } };
-    }
-
-    return { props: {} };
-  };

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Link from 'next/link';
 import AuthForm from 'components/AuthForm';
+import PageLoading from 'components/PageLoading';
 import { useAuth } from 'utils/useAuth';
 
 export default function Login() {
@@ -19,7 +20,7 @@ export default function Login() {
   }, [router, user, isLoaded]);
 
   if (!isPageLoaded) {
-    return <div>Loading...</div>;
+    return <PageLoading />;
   }
 
   return (

--- a/utils/useAuth.tsx
+++ b/utils/useAuth.tsx
@@ -69,13 +69,7 @@ function useProvideAuth(): AuthContextType {
   useEffect(() => {
     const { data: authListener } = supabase.auth.onAuthStateChange(
       async (event, session) => {
-        // Set auth cookie and update user
-        await fetch('/api/auth', {
-          method: 'POST',
-          headers: new Headers({ 'Content-Type': 'application/json' }),
-          credentials: 'same-origin',
-          body: JSON.stringify({ event, session }),
-        });
+        // Update user
         updateUser(session?.user ?? null);
 
         // Redirect to /app if the user has signed in


### PR DESCRIPTION
This PR does a few things:
- Moves to client side auth, removing all `getServerSideProps`. This is part of the setup to get Notabase to become an offline-first app. Hopefully it should also fix some issues with auth (such as users not staying logged in).
- Improves performance when resizing graph view
- Makes sidebar persistent
- Adds a new loading indicator when loading the app