### PR TITLE
Improve list normalization

### DIFF
--- a/editor/plugins/withNormalization.ts
+++ b/editor/plugins/withNormalization.ts
@@ -1,5 +1,6 @@
 import { Editor, Element, Node, Selection, Text, Transforms } from 'slate';
 import { ElementType, Mark } from 'types/slate';
+import { isListType } from 'editor/formatting';
 
 const withNormalization = (editor: Editor) => {
   return withListNormalization(withInlineNormalization(editor));
@@ -72,6 +73,20 @@ const withListNormalization = (editor: Editor) => {
             child.type === ElementType.ListItem)
         ) {
           Transforms.unwrapNodes(editor, { at: childPath });
+          return;
+        }
+      }
+    }
+
+    // Convert paragraphs to list items if they are the children of a list
+    if (Element.isElement(node) && isListType(node.type)) {
+      for (const [child, childPath] of Node.children(editor, path)) {
+        if (Element.isElement(child) && child.type === ElementType.Paragraph) {
+          Transforms.setNodes(
+            editor,
+            { type: ElementType.ListItem },
+            { at: childPath }
+          );
           return;
         }
       }

--- a/editor/serialization/deserialize.ts
+++ b/editor/serialization/deserialize.ts
@@ -21,12 +21,16 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
+import { Descendant } from 'slate';
 import { ElementType, Mark } from 'types/slate';
 import { MdastNode } from './types';
 
 export type OptionType = Record<string, never>;
 
-export default function deserialize(node: MdastNode, opts?: OptionType) {
+export default function deserialize(
+  node: MdastNode,
+  opts?: OptionType
+): Descendant {
   let children = [{ text: '' }];
 
   if (
@@ -70,23 +74,25 @@ export default function deserialize(node: MdastNode, opts?: OptionType) {
       return { type: ElementType.Paragraph, children };
 
     case 'link':
-      return { type: ElementType.ExternalLink, url: node.url, children };
+      return { type: ElementType.ExternalLink, url: node.url ?? '', children };
     case 'wikiLink':
       // Note ids are omitted and are added later
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       return {
         type: ElementType.NoteLink,
-        noteTitle: node.value,
+        noteTitle: node.value ?? '',
         ...(node.data?.alias && node.data.alias !== node.value
           ? { customText: node.data.alias }
           : {}),
-        children: [{ text: node.value }],
+        children: [{ text: node.value ?? '' }],
       };
 
     case 'image':
       return {
         type: ElementType.Image,
         children: [{ text: '' }],
-        url: node.url,
+        url: node.url ?? '',
         caption: node.alt,
       };
     case 'blockquote':
@@ -95,7 +101,7 @@ export default function deserialize(node: MdastNode, opts?: OptionType) {
       return {
         type: ElementType.CodeBlock,
         // language: node.lang,
-        children: [{ text: node.value }],
+        children: [{ text: node.value ?? '' }],
       };
 
     case 'html':
@@ -122,7 +128,7 @@ export default function deserialize(node: MdastNode, opts?: OptionType) {
     case 'inlineCode':
       return {
         [Mark.Code]: true,
-        text: node.value,
+        text: node.value ?? '',
         ...persistLeafFormats(children),
       };
     case 'thematicBreak':

--- a/editor/serialization/normalize.ts
+++ b/editor/serialization/normalize.ts
@@ -34,7 +34,7 @@ const normalizeLists = (node: MdastNode): MdastNode => {
     }
 
     // Iterate through the children of the list item
-    if (child.type === 'listItem') {
+    if (normalizedChild.type === 'listItem') {
       const nestedLists = [];
       const newNestedChildren = [];
       for (const nestedChild of normalizedChild.children) {

--- a/editor/serialization/normalize.ts
+++ b/editor/serialization/normalize.ts
@@ -47,8 +47,11 @@ const normalizeLists = (node: MdastNode): MdastNode => {
         if (nestedChild.type === 'list') {
           // If the list item child is a list, add it to nestedLists
           nestedLists.push(nestedChild);
-        } else if (nestedChild.type === 'paragraph') {
-          // If the list item child is a paragraph, remove the paragraph wrapper
+        } else if (
+          nestedChild.type === 'paragraph' ||
+          nestedChild.type === 'heading'
+        ) {
+          // If the list item child is a paragraph or heading, remove the wrapper
           newNestedChildren.push(...(nestedChild.children ?? []));
         } else {
           // If the list item child is anything else (e.g. list item), add it normally

--- a/editor/serialization/normalize.ts
+++ b/editor/serialization/normalize.ts
@@ -84,13 +84,11 @@ const normalizeImages = (node: MdastNode): MdastNode => {
   for (const child of node.children) {
     const normalizedChild = normalizeImages(child); // Normalize child
 
-    // If the child contains an image and adjacent text, we want to pull the image out into its own block
+    // Pull the image out into its own block if it's not the child of a list
     if (
+      normalizedChild.type !== 'list' &&
       normalizedChild.children?.some(
         (nestedChild) => nestedChild.type === 'image'
-      ) &&
-      normalizedChild.children?.some(
-        (nestedChild) => nestedChild.type === 'text'
       )
     ) {
       const blocks: MdastNode[] = [];
@@ -99,7 +97,9 @@ const normalizeImages = (node: MdastNode): MdastNode => {
       for (const nestedChild of normalizedChild.children) {
         if (nestedChild.type === 'image') {
           blocks.push(nestedChild);
-        } else {
+        }
+        // Nested child is a text node
+        else {
           // Add a new block if it doesn't exist yet
           if (
             blocks.length <= 0 ||

--- a/editor/serialization/normalize.ts
+++ b/editor/serialization/normalize.ts
@@ -84,10 +84,16 @@ const normalizeImages = (node: MdastNode): MdastNode => {
   for (const child of node.children) {
     const normalizedChild = normalizeImages(child); // Normalize child
 
+    if (!normalizedChild.children) {
+      // No children, just push in normally
+      newChildren.push(normalizedChild);
+      continue;
+    }
+
     // Pull the image out into its own block if it's not the child of a list
     if (
       normalizedChild.type !== 'list' &&
-      normalizedChild.children?.some(
+      normalizedChild.children.some(
         (nestedChild) => nestedChild.type === 'image'
       )
     ) {

--- a/editor/serialization/remarkToSlate.ts
+++ b/editor/serialization/remarkToSlate.ts
@@ -1,11 +1,23 @@
+import { DEFAULT_EDITOR_VALUE } from 'editor/constants';
 import normalize from './normalize';
 import deserialize, { OptionType } from './deserialize';
 import { MdastNode } from './types';
 
 export default function remarkToSlate(opts?: OptionType) {
   const compiler = (node: { children: Array<MdastNode> }) => {
+    // Normalize to conform to Notabase's slate schema
     const normalizedNode = normalize(node);
-    return normalizedNode.children?.map((c) => deserialize(c, opts));
+
+    if (!normalizedNode.children) {
+      return DEFAULT_EDITOR_VALUE;
+    }
+
+    // Deserialize MdastNode into slate document
+    const slateContent = normalizedNode.children.map((c) =>
+      deserialize(c, opts)
+    );
+
+    return slateContent;
   };
 
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment

--- a/pages/changelog.tsx
+++ b/pages/changelog.tsx
@@ -29,6 +29,7 @@ export default function Changelog() {
             'You can now sort notes by date modified or created',
             'The date modified or created for each note is now visible in the dropdown',
           ]}
+          bugFixes={['Improve list normalization']}
         />
         <ChangelogBlock
           title="August 29, 2021"


### PR DESCRIPTION
This PR improves normalization around lists.
- Strips out paragraphs/headings/list items in list items
- Converts paragraphs to list items if they are the children of a list
- Pulls images out into their own block if they are not the child of a list (only during deserialization)
