### PR TITLE
Move block formatting

### DIFF
--- a/components/Dropdown.tsx
+++ b/components/Dropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, ReactNode } from 'react';
+import { useState, ReactNode, MouseEventHandler } from 'react';
 import { usePopper } from 'react-popper';
 import { Menu } from '@headlessui/react';
 import { Placement } from '@popperjs/core';
@@ -60,7 +60,7 @@ export default function Dropdown(props: Props) {
             <Portal>
               <Menu.Items
                 ref={setPopperElement}
-                className={`z-10 w-48 overflow-hidden text-sm bg-white rounded shadow-popover dark:bg-gray-800 ${itemsClassName}`}
+                className={`z-10 w-52 overflow-hidden text-sm bg-white rounded shadow-popover dark:bg-gray-800 ${itemsClassName}`}
                 static
                 style={styles.popper}
                 {...attributes.popper}
@@ -76,7 +76,7 @@ export default function Dropdown(props: Props) {
 }
 
 type DropdownItemProps = {
-  onClick: () => void;
+  onClick: MouseEventHandler<HTMLButtonElement>;
   children: ReactNode;
   className?: string;
 };
@@ -87,7 +87,7 @@ export function DropdownItem(props: DropdownItemProps) {
     <Menu.Item>
       {({ active }) => (
         <button
-          className={`flex w-full items-center px-4 py-2 text-left text-gray-800 dark:text-gray-200 ${
+          className={`flex w-full items-center px-4 py-2 text-left text-gray-800 dark:text-gray-200 select-none ${
             active ? 'bg-gray-100 dark:bg-gray-700' : ''
           } ${className}`}
           onClick={onClick}

--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -41,7 +41,7 @@ import HoveringToolbar from './HoveringToolbar';
 import AddLinkPopover from './AddLinkPopover';
 import EditorElement from './elements/EditorElement';
 import withVerticalSpacing from './elements/withVerticalSpacing';
-import withBlockSideMenu from './elements/withBlockSideMenu';
+import withBlockSideMenu from './blockmenu/withBlockSideMenu';
 import EditorLeaf from './elements/EditorLeaf';
 import LinkAutocompletePopover from './LinkAutocompletePopover';
 import BlockAutocompletePopover from './BlockAutocompletePopover';

--- a/components/editor/HoveringToolbar.tsx
+++ b/components/editor/HoveringToolbar.tsx
@@ -7,21 +7,9 @@ import {
   IconUnderline,
   IconStrikethrough,
   IconCode,
-  IconH1,
-  IconH2,
-  IconH3,
-  IconBlockquote,
-  IconList,
-  IconListNumbers,
   IconLink,
-  IconBraces,
 } from '@tabler/icons';
-import {
-  toggleMark,
-  isMarkActive,
-  toggleElement,
-  isElementActive,
-} from 'editor/formatting';
+import { toggleMark, isMarkActive, isElementActive } from 'editor/formatting';
 import { ElementType, Mark } from 'types/slate';
 import Tooltip from 'components/Tooltip';
 import EditorPopover from './EditorPopover';
@@ -42,17 +30,7 @@ export default function HoveringToolbar(props: Props) {
       <FormatButton format={Mark.Italic} />
       <FormatButton format={Mark.Underline} />
       <FormatButton format={Mark.Strikethrough} />
-      <FormatButton
-        format={Mark.Code}
-        className="border-r dark:border-gray-700"
-      />
-      <BlockButton format={ElementType.HeadingOne} />
-      <BlockButton format={ElementType.HeadingTwo} />
-      <BlockButton format={ElementType.HeadingThree} />
-      <BlockButton format={ElementType.BulletedList} />
-      <BlockButton format={ElementType.NumberedList} />
-      <BlockButton format={ElementType.Blockquote} />
-      <BlockButton format={ElementType.CodeBlock} />
+      <FormatButton format={Mark.Code} />
     </EditorPopover>
   );
 }
@@ -66,7 +44,7 @@ type ToolbarButtonProps = {
   className?: string;
 };
 
-const ToolbarButton = (props: ToolbarButtonProps) => {
+export const ToolbarButton = (props: ToolbarButtonProps) => {
   const {
     icon: Icon,
     onClick,
@@ -148,68 +126,6 @@ const FormatButton = ({ format, className = '' }: FormatButtonProps) => {
     <ToolbarButton
       icon={Icon}
       onClick={() => toggleMark(editor, format)}
-      isActive={isActive}
-      className={className}
-      tooltip={tooltip}
-    />
-  );
-};
-
-type BlockButtonProps = {
-  format: ElementType;
-  className?: string;
-};
-
-const BlockButton = ({ format, className = '' }: BlockButtonProps) => {
-  const editor = useSlate();
-  const isActive = isElementActive(editor, format);
-
-  const Icon = useMemo(() => {
-    switch (format) {
-      case ElementType.HeadingOne:
-        return IconH1;
-      case ElementType.HeadingTwo:
-        return IconH2;
-      case ElementType.HeadingThree:
-        return IconH3;
-      case ElementType.BulletedList:
-        return IconList;
-      case ElementType.NumberedList:
-        return IconListNumbers;
-      case ElementType.Blockquote:
-        return IconBlockquote;
-      case ElementType.CodeBlock:
-        return IconBraces;
-      default:
-        throw new Error(`Format ${format} is not a valid format`);
-    }
-  }, [format]);
-
-  const tooltip = useMemo(() => {
-    switch (format) {
-      case ElementType.HeadingOne:
-        return 'Heading 1';
-      case ElementType.HeadingTwo:
-        return 'Heading 2';
-      case ElementType.HeadingThree:
-        return 'Heading 3';
-      case ElementType.BulletedList:
-        return 'Bulleted List';
-      case ElementType.NumberedList:
-        return 'Numbered List';
-      case ElementType.Blockquote:
-        return 'Quote Block';
-      case ElementType.CodeBlock:
-        return 'Code Block';
-      default:
-        return undefined;
-    }
-  }, [format]);
-
-  return (
-    <ToolbarButton
-      icon={Icon}
-      onClick={() => toggleElement(editor, format)}
       isActive={isActive}
       className={className}
       tooltip={tooltip}

--- a/components/editor/blockmenu/BacklinksPopover.tsx
+++ b/components/editor/blockmenu/BacklinksPopover.tsx
@@ -1,5 +1,4 @@
 import {
-  ComponentType,
   useCallback,
   useMemo,
   useState,
@@ -7,117 +6,15 @@ import {
   useRef,
   Fragment,
 } from 'react';
-import { Element, Node, Transforms } from 'slate';
-import { ReactEditor, useSlateStatic } from 'slate-react';
-import { IconDotsVertical, IconLink } from '@tabler/icons';
+import { Node } from 'slate';
 import { Popover } from '@headlessui/react';
 import { usePopper } from 'react-popper';
-import { ReferenceableBlockElement, ElementType } from 'types/slate';
-import Dropdown, { DropdownItem } from 'components/Dropdown';
+import { ReferenceableBlockElement } from 'types/slate';
 import Portal from 'components/Portal';
-import { isReferenceableBlockElement } from 'editor/checks';
 import updateBlockBacklinks from 'editor/backlinks/updateBlockBacklinks';
-import { createNodeId } from 'editor/plugins/withNodeId';
 import { shallowEqual, Store, useStore } from 'lib/store';
 import BlockBacklinks from '../backlinks/BlockBacklinks';
 import { getNumOfMatches } from '../backlinks/Backlinks';
-import { EditorElementProps } from './EditorElement';
-
-export default function withBlockSideMenu(
-  EditorElement: ComponentType<EditorElementProps>
-) {
-  const ElementWithSideMenu = (props: EditorElementProps) => {
-    const { element } = props;
-
-    if (!isReferenceableBlockElement(element)) {
-      return <EditorElement {...props} />;
-    }
-
-    return (
-      <div className="relative w-full group before:absolute before:top-0 before:bottom-0 before:w-full before:right-full">
-        <EditorElement {...props} />
-        <OptionsMenuDropdown element={element} />
-        <BacklinksPopover element={element} />
-      </div>
-    );
-  };
-
-  return ElementWithSideMenu;
-}
-
-type OptionsMenuDropdownProps = {
-  element: ReferenceableBlockElement;
-};
-
-const OptionsMenuDropdown = (props: OptionsMenuDropdownProps) => {
-  const { element } = props;
-  const editor = useSlateStatic();
-
-  const onCopyBlockRef = useCallback(async () => {
-    let blockId;
-
-    // We still need this because there are cases where block ids might not exist
-    if (!element.id) {
-      // Generate block id if it doesn't exist
-      blockId = createNodeId();
-      const path = ReactEditor.findPath(editor, element);
-      Transforms.setNodes(
-        editor,
-        { id: blockId },
-        {
-          at: path,
-          match: (n) =>
-            Element.isElement(n) &&
-            isReferenceableBlockElement(n) &&
-            n.type === element.type,
-        }
-      );
-    } else {
-      // Use the existing block id
-      blockId = element.id;
-    }
-
-    navigator.clipboard.writeText(`((${blockId}))`);
-  }, [editor, element]);
-
-  const buttonChildren = useMemo(
-    () => (
-      <span className="flex items-center justify-center w-6 h-6">
-        <IconDotsVertical
-          className="text-gray-500 dark:text-gray-400"
-          size={18}
-        />
-      </span>
-    ),
-    []
-  );
-
-  const buttonClassName = useMemo(() => {
-    const className =
-      'hidden group-hover:block select-none hover:bg-gray-200 active:bg-gray-300 rounded absolute top-0.5 dark:hover:bg-gray-800 dark:active:bg-gray-700';
-    if (element.type === ElementType.ListItem) {
-      return `${className} -left-16`;
-    } else {
-      return `${className} -left-8`;
-    }
-  }, [element.type]);
-
-  return (
-    <Dropdown
-      buttonChildren={buttonChildren}
-      buttonClassName={buttonClassName}
-      placement="left"
-      offset={[0, 6]}
-      tooltipContent={<span className="text-xs">Click to open menu</span>}
-      tooltipPlacement="bottom"
-    >
-      <DropdownItem onClick={onCopyBlockRef}>
-        <IconLink size={18} className="mr-1" />
-        <span>Copy block reference</span>
-      </DropdownItem>
-    </Dropdown>
-  );
-};
 
 const UPDATE_BLOCK_BACKLINKS_DEBOUNCE_MS = 500;
 
@@ -125,7 +22,7 @@ type BacklinksPopoverProps = {
   element: ReferenceableBlockElement;
 };
 
-const BacklinksPopover = (props: BacklinksPopoverProps) => {
+export default function BacklinksPopover(props: BacklinksPopoverProps) {
   const { element } = props;
 
   const [referenceElement, setReferenceElement] =
@@ -205,4 +102,4 @@ const BacklinksPopover = (props: BacklinksPopoverProps) => {
       )}
     </Popover>
   ) : null;
-};
+}

--- a/components/editor/blockmenu/BlockMenuDropdown.tsx
+++ b/components/editor/blockmenu/BlockMenuDropdown.tsx
@@ -1,0 +1,84 @@
+import { useCallback, useMemo } from 'react';
+import { Element, Transforms } from 'slate';
+import { ReactEditor, useSlateStatic } from 'slate-react';
+import { IconDotsVertical, IconLink } from '@tabler/icons';
+import { ReferenceableBlockElement, ElementType } from 'types/slate';
+import Dropdown, { DropdownItem } from 'components/Dropdown';
+import { isReferenceableBlockElement } from 'editor/checks';
+import { createNodeId } from 'editor/plugins/withNodeId';
+import ChangeBlockOptions from './ChangeBlockOptions';
+
+type BlockMenuDropdownProps = {
+  element: ReferenceableBlockElement;
+};
+
+export default function BlockMenuDropdown(props: BlockMenuDropdownProps) {
+  const { element } = props;
+  const editor = useSlateStatic();
+
+  const onCopyBlockRef = useCallback(async () => {
+    let blockId;
+
+    // We still need this because there are cases where block ids might not exist
+    if (!element.id) {
+      // Generate block id if it doesn't exist
+      blockId = createNodeId();
+      const path = ReactEditor.findPath(editor, element);
+      Transforms.setNodes(
+        editor,
+        { id: blockId },
+        {
+          at: path,
+          match: (n) =>
+            Element.isElement(n) &&
+            isReferenceableBlockElement(n) &&
+            n.type === element.type,
+        }
+      );
+    } else {
+      // Use the existing block id
+      blockId = element.id;
+    }
+
+    navigator.clipboard.writeText(`((${blockId}))`);
+  }, [editor, element]);
+
+  const buttonChildren = useMemo(
+    () => (
+      <span className="flex items-center justify-center w-6 h-6">
+        <IconDotsVertical
+          className="text-gray-500 dark:text-gray-400"
+          size={18}
+        />
+      </span>
+    ),
+    []
+  );
+
+  const buttonClassName = useMemo(() => {
+    const className =
+      'hidden group-hover:block select-none hover:bg-gray-200 active:bg-gray-300 rounded absolute top-0.5 dark:hover:bg-gray-800 dark:active:bg-gray-700';
+    if (element.type === ElementType.ListItem) {
+      return `${className} -left-16`;
+    } else {
+      return `${className} -left-8`;
+    }
+  }, [element.type]);
+
+  return (
+    <Dropdown
+      buttonChildren={buttonChildren}
+      buttonClassName={buttonClassName}
+      placement="left-start"
+      offset={[0, 6]}
+      tooltipContent={<span className="text-xs">Click to open menu</span>}
+      tooltipPlacement="bottom"
+    >
+      <DropdownItem onClick={onCopyBlockRef}>
+        <IconLink size={18} className="mr-1" />
+        <span>Copy block reference</span>
+      </DropdownItem>
+      <ChangeBlockOptions element={element} />
+    </Dropdown>
+  );
+}

--- a/components/editor/blockmenu/BlockMenuDropdown.tsx
+++ b/components/editor/blockmenu/BlockMenuDropdown.tsx
@@ -78,7 +78,10 @@ export default function BlockMenuDropdown(props: BlockMenuDropdownProps) {
         <IconLink size={18} className="mr-1" />
         <span>Copy block reference</span>
       </DropdownItem>
-      <ChangeBlockOptions element={element} />
+      <ChangeBlockOptions
+        element={element}
+        className="px-4 py-2 border-t dark:border-gray-700"
+      />
     </Dropdown>
   );
 }

--- a/components/editor/blockmenu/ChangeBlockOptions.tsx
+++ b/components/editor/blockmenu/ChangeBlockOptions.tsx
@@ -8,7 +8,6 @@ import {
   IconList,
   IconListNumbers,
   IconBraces,
-  IconSwitch,
   IconTypography,
   TablerIcon,
 } from '@tabler/icons';
@@ -20,17 +19,14 @@ import { DropdownItem } from 'components/Dropdown';
 
 type ChangeBlockOptionsProps = {
   element: Element;
+  className?: string;
 };
 
 export default function ChangeBlockOptions(props: ChangeBlockOptionsProps) {
-  const { element } = props;
+  const { element, className = '' } = props;
   return (
-    <div className="px-4 py-2">
-      <p className="flex items-center pb-2 select-none dark:text-gray-200">
-        <IconSwitch size={18} className="mr-1" />
-        <span>Turn block into:</span>
-      </p>
-      <div className="flex items-center justify-center pb-2 space-x-2">
+    <div className={`space-y-2 ${className}`}>
+      <div className="flex items-center justify-center space-x-2">
         <BlockButton
           format={ElementType.Paragraph}
           element={element}
@@ -69,6 +65,8 @@ export default function ChangeBlockOptions(props: ChangeBlockOptionsProps) {
           Icon={IconListNumbers}
           tooltip="Numbered List"
         />
+      </div>
+      <div className="flex items-center justify-center space-x-2">
         <BlockButton
           format={ElementType.Blockquote}
           element={element}

--- a/components/editor/blockmenu/ChangeBlockOptions.tsx
+++ b/components/editor/blockmenu/ChangeBlockOptions.tsx
@@ -1,0 +1,116 @@
+import { useMemo } from 'react';
+import { ReactEditor, useSlate } from 'slate-react';
+import {
+  IconH1,
+  IconH2,
+  IconH3,
+  IconBlockquote,
+  IconList,
+  IconListNumbers,
+  IconBraces,
+  IconSwitch,
+  IconTypography,
+} from '@tabler/icons';
+import { Element } from 'slate';
+import { toggleElement, isElementActive } from 'editor/formatting';
+import { ElementType } from 'types/slate';
+import { ToolbarButton } from '../HoveringToolbar';
+
+type ChangeBlockOptionsProps = {
+  element: Element;
+};
+
+export default function ChangeBlockOptions(props: ChangeBlockOptionsProps) {
+  const { element } = props;
+  return (
+    <div className="px-4 py-2">
+      <p className="flex items-center pb-2 select-none dark:text-gray-200">
+        <IconSwitch size={18} className="mr-1" />
+        <span>Turn block into:</span>
+      </p>
+      <div className="flex items-center justify-center pb-2 space-x-2">
+        <BlockButton format={ElementType.Paragraph} element={element} />
+        <BlockButton format={ElementType.HeadingOne} element={element} />
+        <BlockButton format={ElementType.HeadingTwo} element={element} />
+        <BlockButton format={ElementType.HeadingThree} element={element} />
+      </div>
+      <div className="flex items-center justify-center space-x-2">
+        <BlockButton format={ElementType.BulletedList} element={element} />
+        <BlockButton format={ElementType.NumberedList} element={element} />
+        <BlockButton format={ElementType.Blockquote} element={element} />
+        <BlockButton format={ElementType.CodeBlock} element={element} />
+      </div>
+    </div>
+  );
+}
+
+type BlockButtonProps = {
+  format: ElementType;
+  element: Element;
+  className?: string;
+};
+
+const BlockButton = ({ format, element, className = '' }: BlockButtonProps) => {
+  const editor = useSlate();
+  const path = useMemo(
+    () => ReactEditor.findPath(editor, element),
+    [editor, element]
+  );
+  const isActive = isElementActive(editor, format, path);
+
+  const Icon = useMemo(() => {
+    switch (format) {
+      case ElementType.Paragraph:
+        return IconTypography;
+      case ElementType.HeadingOne:
+        return IconH1;
+      case ElementType.HeadingTwo:
+        return IconH2;
+      case ElementType.HeadingThree:
+        return IconH3;
+      case ElementType.BulletedList:
+        return IconList;
+      case ElementType.NumberedList:
+        return IconListNumbers;
+      case ElementType.Blockquote:
+        return IconBlockquote;
+      case ElementType.CodeBlock:
+        return IconBraces;
+      default:
+        throw new Error(`Format ${format} is not a valid format`);
+    }
+  }, [format]);
+
+  const tooltip = useMemo(() => {
+    switch (format) {
+      case ElementType.Paragraph:
+        return 'Paragraph';
+      case ElementType.HeadingOne:
+        return 'Heading 1';
+      case ElementType.HeadingTwo:
+        return 'Heading 2';
+      case ElementType.HeadingThree:
+        return 'Heading 3';
+      case ElementType.BulletedList:
+        return 'Bulleted List';
+      case ElementType.NumberedList:
+        return 'Numbered List';
+      case ElementType.Blockquote:
+        return 'Quote Block';
+      case ElementType.CodeBlock:
+        return 'Code Block';
+      default:
+        return undefined;
+    }
+  }, [format]);
+
+  return (
+    <ToolbarButton
+      icon={Icon}
+      onClick={() => toggleElement(editor, format, path)}
+      isActive={isActive}
+      className={`border rounded dark:border-gray-700 ${className}`}
+      tooltip={tooltip}
+    />
+  );
+};

--- a/components/editor/blockmenu/ChangeBlockOptions.tsx
+++ b/components/editor/blockmenu/ChangeBlockOptions.tsx
@@ -10,6 +10,7 @@ import {
   IconBraces,
   IconSwitch,
   IconTypography,
+  TablerIcon,
 } from '@tabler/icons';
 import { Element } from 'slate';
 import { toggleElement, isElementActive } from 'editor/formatting';
@@ -30,16 +31,56 @@ export default function ChangeBlockOptions(props: ChangeBlockOptionsProps) {
         <span>Turn block into:</span>
       </p>
       <div className="flex items-center justify-center pb-2 space-x-2">
-        <BlockButton format={ElementType.Paragraph} element={element} />
-        <BlockButton format={ElementType.HeadingOne} element={element} />
-        <BlockButton format={ElementType.HeadingTwo} element={element} />
-        <BlockButton format={ElementType.HeadingThree} element={element} />
+        <BlockButton
+          format={ElementType.Paragraph}
+          element={element}
+          Icon={IconTypography}
+          tooltip="Paragraph"
+        />
+        <BlockButton
+          format={ElementType.HeadingOne}
+          element={element}
+          Icon={IconH1}
+          tooltip="Heading 1"
+        />
+        <BlockButton
+          format={ElementType.HeadingTwo}
+          element={element}
+          Icon={IconH2}
+          tooltip="Heading 2"
+        />
+        <BlockButton
+          format={ElementType.HeadingThree}
+          element={element}
+          Icon={IconH3}
+          tooltip="Heading 3"
+        />
       </div>
       <div className="flex items-center justify-center space-x-2">
-        <BlockButton format={ElementType.BulletedList} element={element} />
-        <BlockButton format={ElementType.NumberedList} element={element} />
-        <BlockButton format={ElementType.Blockquote} element={element} />
-        <BlockButton format={ElementType.CodeBlock} element={element} />
+        <BlockButton
+          format={ElementType.BulletedList}
+          element={element}
+          Icon={IconList}
+          tooltip="Bulleted List"
+        />
+        <BlockButton
+          format={ElementType.NumberedList}
+          element={element}
+          Icon={IconListNumbers}
+          tooltip="Numbered List"
+        />
+        <BlockButton
+          format={ElementType.Blockquote}
+          element={element}
+          Icon={IconBlockquote}
+          tooltip="Quote Block"
+        />
+        <BlockButton
+          format={ElementType.CodeBlock}
+          element={element}
+          Icon={IconBraces}
+          tooltip="Code Block"
+        />
       </div>
     </div>
   );
@@ -48,62 +89,24 @@ export default function ChangeBlockOptions(props: ChangeBlockOptionsProps) {
 type BlockButtonProps = {
   format: ElementType;
   element: Element;
+  Icon: TablerIcon;
+  tooltip?: string;
   className?: string;
 };
 
-const BlockButton = ({ format, element, className = '' }: BlockButtonProps) => {
+const BlockButton = ({
+  format,
+  element,
+  Icon,
+  tooltip,
+  className = '',
+}: BlockButtonProps) => {
   const editor = useSlate();
   const path = useMemo(
     () => ReactEditor.findPath(editor, element),
     [editor, element]
   );
   const isActive = isElementActive(editor, format, path);
-
-  const Icon = useMemo(() => {
-    switch (format) {
-      case ElementType.Paragraph:
-        return IconTypography;
-      case ElementType.HeadingOne:
-        return IconH1;
-      case ElementType.HeadingTwo:
-        return IconH2;
-      case ElementType.HeadingThree:
-        return IconH3;
-      case ElementType.BulletedList:
-        return IconList;
-      case ElementType.NumberedList:
-        return IconListNumbers;
-      case ElementType.Blockquote:
-        return IconBlockquote;
-      case ElementType.CodeBlock:
-        return IconBraces;
-      default:
-        throw new Error(`Format ${format} is not a valid format`);
-    }
-  }, [format]);
-
-  const tooltip = useMemo(() => {
-    switch (format) {
-      case ElementType.Paragraph:
-        return 'Paragraph';
-      case ElementType.HeadingOne:
-        return 'Heading 1';
-      case ElementType.HeadingTwo:
-        return 'Heading 2';
-      case ElementType.HeadingThree:
-        return 'Heading 3';
-      case ElementType.BulletedList:
-        return 'Bulleted List';
-      case ElementType.NumberedList:
-        return 'Numbered List';
-      case ElementType.Blockquote:
-        return 'Quote Block';
-      case ElementType.CodeBlock:
-        return 'Code Block';
-      default:
-        return undefined;
-    }
-  }, [format]);
 
   return (
     <Tooltip content={tooltip} placement="top" disabled={!tooltip}>

--- a/components/editor/blockmenu/ChangeBlockOptions.tsx
+++ b/components/editor/blockmenu/ChangeBlockOptions.tsx
@@ -14,7 +14,8 @@ import {
 import { Element } from 'slate';
 import { toggleElement, isElementActive } from 'editor/formatting';
 import { ElementType } from 'types/slate';
-import { ToolbarButton } from '../HoveringToolbar';
+import Tooltip from 'components/Tooltip';
+import { DropdownItem } from 'components/Dropdown';
 
 type ChangeBlockOptionsProps = {
   element: Element;
@@ -105,12 +106,22 @@ const BlockButton = ({ format, element, className = '' }: BlockButtonProps) => {
   }, [format]);
 
   return (
-    <ToolbarButton
-      icon={Icon}
-      onClick={() => toggleElement(editor, format, path)}
-      isActive={isActive}
-      className={`border rounded dark:border-gray-700 ${className}`}
-      tooltip={tooltip}
-    />
+    <Tooltip content={tooltip} placement="top" disabled={!tooltip}>
+      <span>
+        <DropdownItem
+          className={`flex items-center px-2 py-2 cursor-pointer border rounded hover:bg-gray-100 active:bg-gray-200 dark:hover:bg-gray-700 dark:active:bg-gray-600 dark:border-gray-700 ${className}`}
+          onClick={() => toggleElement(editor, format, path)}
+        >
+          <Icon
+            size={18}
+            className={
+              isActive
+                ? 'text-primary-500 dark:text-primary-400'
+                : 'text-gray-800 dark:text-gray-200'
+            }
+          />
+        </DropdownItem>
+      </span>
+    </Tooltip>
   );
 };

--- a/components/editor/blockmenu/withBlockSideMenu.tsx
+++ b/components/editor/blockmenu/withBlockSideMenu.tsx
@@ -1,0 +1,27 @@
+import { ComponentType } from 'react';
+import { isReferenceableBlockElement } from 'editor/checks';
+import { EditorElementProps } from '../elements/EditorElement';
+import BacklinksPopover from './BacklinksPopover';
+import BlockMenuDropdown from './BlockMenuDropdown';
+
+export default function withBlockSideMenu(
+  EditorElement: ComponentType<EditorElementProps>
+) {
+  const ElementWithSideMenu = (props: EditorElementProps) => {
+    const { element } = props;
+
+    if (!isReferenceableBlockElement(element)) {
+      return <EditorElement {...props} />;
+    }
+
+    return (
+      <div className="relative w-full group before:absolute before:top-0 before:bottom-0 before:w-full before:right-full">
+        <EditorElement {...props} />
+        <BlockMenuDropdown element={element} />
+        <BacklinksPopover element={element} />
+      </div>
+    );
+  };
+
+  return ElementWithSideMenu;
+}

--- a/editor/checks.ts
+++ b/editor/checks.ts
@@ -18,3 +18,18 @@ export const isReferenceableBlockElement = (
     element.type === ElementType.BlockReference
   );
 };
+
+export const isTextType = (
+  type: ElementType
+): type is
+  | ElementType.Paragraph
+  | ElementType.HeadingOne
+  | ElementType.HeadingTwo
+  | ElementType.HeadingThree => {
+  return (
+    type === ElementType.Paragraph ||
+    type === ElementType.HeadingOne ||
+    type === ElementType.HeadingTwo ||
+    type === ElementType.HeadingThree
+  );
+};

--- a/editor/formatting.ts
+++ b/editor/formatting.ts
@@ -242,14 +242,21 @@ export const insertNoteLink = (
   wrapLink(editor, link);
 };
 
-export const insertImage = (editor: Editor, url: string) => {
+export const insertImage = (editor: Editor, url: string, path?: Path) => {
   const image: Image = {
     id: createNodeId(),
     type: ElementType.Image,
     url,
     children: [{ text: '' }],
   };
-  Transforms.insertNodes(editor, image);
+
+  if (path) {
+    // Set the node at the given path to be an image
+    Transforms.setNodes(editor, image, { at: path });
+  } else {
+    // Insert a new image node
+    Transforms.insertNodes(editor, image);
+  }
 };
 
 export const insertBlockReference = (

--- a/editor/plugins/withImages.ts
+++ b/editor/plugins/withImages.ts
@@ -1,4 +1,4 @@
-import { Editor } from 'slate';
+import { Editor, Path } from 'slate';
 import { v4 as uuidv4 } from 'uuid';
 import { toast } from 'react-toastify';
 import { insertImage } from 'editor/formatting';
@@ -45,7 +45,11 @@ const isImageUrl = (url: string) => {
   return false;
 };
 
-const uploadAndInsertImage = async (editor: Editor, file: File) => {
+export const uploadAndInsertImage = async (
+  editor: Editor,
+  file: File,
+  path?: Path
+) => {
   const user = supabase.auth.user();
 
   if (!user) {
@@ -83,7 +87,7 @@ const uploadAndInsertImage = async (editor: Editor, file: File) => {
     .createSignedUrl(key, expiresIn);
 
   if (signedURL) {
-    insertImage(editor, signedURL);
+    insertImage(editor, signedURL, path);
   } else if (signedUrlError) {
     toast.error(signedUrlError);
   }

--- a/editor/plugins/withNormalization.ts
+++ b/editor/plugins/withNormalization.ts
@@ -1,6 +1,7 @@
 import { Editor, Element, Node, Selection, Text, Transforms } from 'slate';
 import { ElementType, Mark } from 'types/slate';
 import { isListType } from 'editor/formatting';
+import { isTextType } from 'editor/checks';
 
 const withNormalization = (editor: Editor) => {
   return withListNormalization(withInlineNormalization(editor));
@@ -66,11 +67,7 @@ const withListNormalization = (editor: Editor) => {
       for (const [child, childPath] of Node.children(editor, path)) {
         if (
           Element.isElement(child) &&
-          (child.type === ElementType.Paragraph ||
-            child.type === ElementType.HeadingOne ||
-            child.type === ElementType.HeadingTwo ||
-            child.type === ElementType.HeadingThree ||
-            child.type === ElementType.ListItem)
+          (isTextType(child.type) || child.type === ElementType.ListItem)
         ) {
           Transforms.unwrapNodes(editor, { at: childPath });
           return;
@@ -81,13 +78,7 @@ const withListNormalization = (editor: Editor) => {
     // Convert paragraphs and headings to list items if they are the children of a list
     if (Element.isElement(node) && isListType(node.type)) {
       for (const [child, childPath] of Node.children(editor, path)) {
-        if (
-          Element.isElement(child) &&
-          (child.type === ElementType.Paragraph ||
-            child.type === ElementType.HeadingOne ||
-            child.type === ElementType.HeadingTwo ||
-            child.type === ElementType.HeadingThree)
-        ) {
+        if (Element.isElement(child) && isTextType(child.type)) {
           Transforms.setNodes(
             editor,
             { type: ElementType.ListItem },

--- a/pages/changelog.tsx
+++ b/pages/changelog.tsx
@@ -24,6 +24,13 @@ export default function Changelog() {
           .
         </p>
         <ChangelogBlock
+          title="September 3, 2021"
+          features={[
+            'Move block formatting options to block menu',
+            'Add image button to block menu',
+          ]}
+        />
+        <ChangelogBlock
           title="September 2, 2021"
           bugFixes={['Improve performance when calculating block backlinks']}
         />


### PR DESCRIPTION
This PR:
- moves block formatting options to the block menu
- adds image button to the block formatting options
- improves the way we toggle elements by unwrapping parent lists iteratively if toggling to a text element