### PR TITLE
Set session user directly instead of signing in using refresh token

### DIFF
--- a/utils/useAuth.tsx
+++ b/utils/useAuth.tsx
@@ -35,9 +35,9 @@ function useProvideAuth(): AuthContextType {
   // Initialize the user based on the stored session
   const initUser = useCallback(async () => {
     const session = supabase.auth.session();
-    await supabase.auth.signIn({
-      refreshToken: session?.refresh_token,
-    });
+    if (session) {
+      setUser(session.user);
+    }
     setIsLoaded(true);
   }, []);
 


### PR DESCRIPTION
Hopefully, this fixes a bug where the user gets signed out all the time