### PR TITLE
Add shift click support and page stacking setting

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -39,6 +39,7 @@ import withBlockReferences from 'editor/plugins/withBlockReferences';
 import { store, useStore } from 'lib/store';
 import { ElementType, Mark } from 'types/slate';
 import { DEFAULT_EDITOR_VALUE } from 'editor/constants';
+import useIsMounted from 'utils/useIsMounted';
 import HoveringToolbar from './HoveringToolbar';
 import AddLinkPopover from './AddLinkPopover';
 import EditorElement from './elements/EditorElement';
@@ -63,6 +64,7 @@ type Props = {
 
 function Editor(props: Props) {
   const { noteId, onChange, className = '', highlightedPath } = props;
+  const isMounted = useIsMounted();
 
   const [value, setValue] = useState<Descendant[]>(
     store.getState().notes[noteId]?.content ?? DEFAULT_EDITOR_VALUE
@@ -299,7 +301,11 @@ function Editor(props: Props) {
         placeholder="Start typing here…"
         onKeyDown={onKeyDown}
         onPointerDown={() => setToolbarCanBeVisible(false)}
-        onPointerUp={() => setTimeout(() => setToolbarCanBeVisible(true), 100)}
+        onPointerUp={() =>
+          setTimeout(() => {
+            if (isMounted()) setToolbarCanBeVisible(true);
+          }, 100)
+        }
         spellCheck
       />
     </Slate>

--- a/components/editor/ReadOnlyEditor.tsx
+++ b/components/editor/ReadOnlyEditor.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { memo, useRef } from 'react';
 import { createEditor, Descendant, Editor } from 'slate';
 import { Editable, Slate, withReact } from 'slate-react';
 import withVoidElements from 'editor/plugins/withVoidElements';
@@ -12,7 +12,7 @@ type Props = {
   renderLeaf: (props: EditorLeafProps) => JSX.Element;
 };
 
-export function ReadOnlyEditor(props: Props) {
+function ReadOnlyEditor(props: Props) {
   const { value, renderElement, renderLeaf } = props;
 
   const editorRef = useRef<Editor>();
@@ -39,3 +39,5 @@ export function ReadOnlyEditor(props: Props) {
     </Slate>
   );
 }
+
+export default memo(ReadOnlyEditor);

--- a/components/editor/backlinks/BacklinkMatchLeaf.tsx
+++ b/components/editor/backlinks/BacklinkMatchLeaf.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router';
 import { BacklinkMatch } from 'editor/backlinks/useBacklinks';
 import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
 import { useStore } from 'lib/store';
+import { useCurrentNote } from 'utils/useCurrentNote';
 import EditorElement from '../elements/EditorElement';
 import EditorLeaf from '../elements/EditorLeaf';
 import { ReadOnlyEditor } from '../ReadOnlyEditor';
@@ -15,7 +16,8 @@ type BacklinkMatchLeafProps = {
 
 const BacklinkMatchLeaf = (props: BacklinkMatchLeafProps) => {
   const { noteId, match, className } = props;
-  const onNoteLinkClick = useOnNoteLinkClick();
+  const currentNote = useCurrentNote();
+  const onNoteLinkClick = useOnNoteLinkClick(currentNote.id);
   const isPageStackingOn = useStore((state) => state.isPageStackingOn);
   const router = useRouter();
 
@@ -36,7 +38,7 @@ const BacklinkMatchLeaf = (props: BacklinkMatchLeafProps) => {
       className={containerClassName}
       onClick={(e) => {
         if (isPageStackingOn) {
-          onNoteLinkClick(e, noteId, match.linePath);
+          onNoteLinkClick(noteId, e.shiftKey, match.linePath);
         } else {
           const hash = `#0-${match.linePath}`;
           router.push(`/app/note/${noteId}${hash}`);

--- a/components/editor/backlinks/BacklinkMatchLeaf.tsx
+++ b/components/editor/backlinks/BacklinkMatchLeaf.tsx
@@ -34,9 +34,9 @@ const BacklinkMatchLeaf = (props: BacklinkMatchLeafProps) => {
   return (
     <button
       className={containerClassName}
-      onClick={() => {
+      onClick={(e) => {
         if (isPageStackingOn) {
-          onNoteLinkClick(noteId, match.linePath);
+          onNoteLinkClick(e, noteId, match.linePath);
         } else {
           const hash = `#0-${match.linePath}`;
           router.push(`/app/note/${noteId}${hash}`);

--- a/components/editor/backlinks/BacklinkMatchLeaf.tsx
+++ b/components/editor/backlinks/BacklinkMatchLeaf.tsx
@@ -1,12 +1,10 @@
 import { memo, useMemo } from 'react';
-import { useRouter } from 'next/router';
 import { BacklinkMatch } from 'editor/backlinks/useBacklinks';
 import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
-import { useStore } from 'lib/store';
 import { useCurrentNote } from 'utils/useCurrentNote';
 import EditorElement from '../elements/EditorElement';
 import EditorLeaf from '../elements/EditorLeaf';
-import { ReadOnlyEditor } from '../ReadOnlyEditor';
+import ReadOnlyEditor from '../ReadOnlyEditor';
 
 type BacklinkMatchLeafProps = {
   noteId: string;
@@ -17,35 +15,24 @@ type BacklinkMatchLeafProps = {
 const BacklinkMatchLeaf = (props: BacklinkMatchLeafProps) => {
   const { noteId, match, className } = props;
   const currentNote = useCurrentNote();
-  const onNoteLinkClick = useOnNoteLinkClick(currentNote.id);
-  const isPageStackingOn = useStore((state) => state.isPageStackingOn);
-  const router = useRouter();
+  const { onClick: onNoteLinkClick, defaultStackingBehavior } =
+    useOnNoteLinkClick(currentNote.id);
 
-  const backlinkMatch = useMemo(
-    () => (
-      <ReadOnlyEditor
-        value={[match.lineElement]}
-        renderElement={EditorElement}
-        renderLeaf={EditorLeaf}
-      />
-    ),
-    [match.lineElement]
-  );
+  const editorValue = useMemo(() => [match.lineElement], [match.lineElement]);
   const containerClassName = `block text-left text-xs rounded p-2 my-1 w-full break-words ${className}`;
 
   return (
     <button
       className={containerClassName}
-      onClick={(e) => {
-        if (isPageStackingOn) {
-          onNoteLinkClick(noteId, e.shiftKey, match.linePath);
-        } else {
-          const hash = `#0-${match.linePath}`;
-          router.push(`/app/note/${noteId}${hash}`);
-        }
-      }}
+      onClick={(e) =>
+        onNoteLinkClick(noteId, defaultStackingBehavior(e), match.linePath)
+      }
     >
-      {backlinkMatch}
+      <ReadOnlyEditor
+        value={editorValue}
+        renderElement={EditorElement}
+        renderLeaf={EditorLeaf}
+      />
     </button>
   );
 };

--- a/components/editor/backlinks/BacklinkNoteBranch.tsx
+++ b/components/editor/backlinks/BacklinkNoteBranch.tsx
@@ -18,7 +18,7 @@ const BacklinkNoteBranch = (props: BacklinkNoteBranchProps) => {
       className="py-1 link"
       onClick={(e) => {
         e.stopPropagation();
-        onNoteLinkClick(backlink.id);
+        onNoteLinkClick(e, backlink.id);
       }}
     >
       {backlink.title}

--- a/components/editor/backlinks/BacklinkNoteBranch.tsx
+++ b/components/editor/backlinks/BacklinkNoteBranch.tsx
@@ -1,8 +1,6 @@
 import { memo } from 'react';
-import Link from 'next/link';
 import { Backlink } from 'editor/backlinks/useBacklinks';
 import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
-import { useStore } from 'lib/store';
 import { useCurrentNote } from 'utils/useCurrentNote';
 
 type BacklinkNoteBranchProps = {
@@ -12,25 +10,19 @@ type BacklinkNoteBranchProps = {
 const BacklinkNoteBranch = (props: BacklinkNoteBranchProps) => {
   const { backlink } = props;
   const currentNote = useCurrentNote();
-  const onNoteLinkClick = useOnNoteLinkClick(currentNote.id);
-  const isPageStackingOn = useStore((state) => state.isPageStackingOn);
+  const { onClick: onNoteLinkClick, defaultStackingBehavior } =
+    useOnNoteLinkClick(currentNote.id);
 
-  return isPageStackingOn ? (
+  return (
     <button
       className="py-1 link"
       onClick={(e) => {
         e.stopPropagation();
-        onNoteLinkClick(backlink.id, e.shiftKey);
+        onNoteLinkClick(backlink.id, defaultStackingBehavior(e));
       }}
     >
       {backlink.title}
     </button>
-  ) : (
-    <Link href={`/app/note/${backlink.id}`}>
-      <a className="py-1 link" onClick={(e) => e.stopPropagation()}>
-        {backlink.title}
-      </a>
-    </Link>
   );
 };
 

--- a/components/editor/backlinks/BacklinkNoteBranch.tsx
+++ b/components/editor/backlinks/BacklinkNoteBranch.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { Backlink } from 'editor/backlinks/useBacklinks';
 import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
 import { useStore } from 'lib/store';
+import { useCurrentNote } from 'utils/useCurrentNote';
 
 type BacklinkNoteBranchProps = {
   backlink: Backlink;
@@ -10,7 +11,8 @@ type BacklinkNoteBranchProps = {
 
 const BacklinkNoteBranch = (props: BacklinkNoteBranchProps) => {
   const { backlink } = props;
-  const onNoteLinkClick = useOnNoteLinkClick();
+  const currentNote = useCurrentNote();
+  const onNoteLinkClick = useOnNoteLinkClick(currentNote.id);
   const isPageStackingOn = useStore((state) => state.isPageStackingOn);
 
   return isPageStackingOn ? (
@@ -18,7 +20,7 @@ const BacklinkNoteBranch = (props: BacklinkNoteBranchProps) => {
       className="py-1 link"
       onClick={(e) => {
         e.stopPropagation();
-        onNoteLinkClick(e, backlink.id);
+        onNoteLinkClick(backlink.id, e.shiftKey);
       }}
     >
       {backlink.title}

--- a/components/editor/elements/BlockRefElement.tsx
+++ b/components/editor/elements/BlockRefElement.tsx
@@ -54,7 +54,7 @@ export default function BlockRefElement(props: BlockRefElementProps) {
         onClick={(e) => {
           e.stopPropagation();
           if (blockReference) {
-            onBlockRefClick(blockReference.noteId, blockReference.path);
+            onBlockRefClick(e, blockReference.noteId, blockReference.path);
           }
         }}
         {...attributes}

--- a/components/editor/elements/BlockRefElement.tsx
+++ b/components/editor/elements/BlockRefElement.tsx
@@ -7,7 +7,7 @@ import { useStore } from 'lib/store';
 import Tooltip from 'components/Tooltip';
 import useBlockReference from 'editor/backlinks/useBlockReference';
 import { useCurrentNote } from 'utils/useCurrentNote';
-import { ReadOnlyEditor } from '../ReadOnlyEditor';
+import ReadOnlyEditor from '../ReadOnlyEditor';
 import EditorLeaf from './EditorLeaf';
 import ParagraphElement from './ParagraphElement';
 import EditorElement, { EditorElementProps } from './EditorElement';
@@ -26,7 +26,8 @@ export default function BlockRefElement(props: BlockRefElementProps) {
 
   const blockReference = useBlockReference(element.blockId);
   const currentNote = useCurrentNote();
-  const onBlockRefClick = useOnNoteLinkClick(currentNote.id);
+  const { onClick: onBlockRefClick, defaultStackingBehavior } =
+    useOnNoteLinkClick(currentNote.id);
 
   const blockRefClassName = useMemo(
     () =>
@@ -49,6 +50,11 @@ export default function BlockRefElement(props: BlockRefElementProps) {
     }
   }, []);
 
+  const editorValue = useMemo(
+    () => (blockReference ? [blockReference.element] : []),
+    [blockReference]
+  );
+
   return (
     <Tooltip content={noteTitle} placement="bottom-start" disabled={!noteTitle}>
       <div
@@ -58,7 +64,7 @@ export default function BlockRefElement(props: BlockRefElementProps) {
           if (blockReference) {
             onBlockRefClick(
               blockReference.noteId,
-              e.shiftKey,
+              defaultStackingBehavior(e),
               blockReference.path
             );
           }
@@ -67,7 +73,7 @@ export default function BlockRefElement(props: BlockRefElementProps) {
       >
         {blockReference ? (
           <ReadOnlyEditor
-            value={[blockReference.element]}
+            value={editorValue}
             renderElement={renderElement}
             renderLeaf={EditorLeaf}
           />

--- a/components/editor/elements/BlockRefElement.tsx
+++ b/components/editor/elements/BlockRefElement.tsx
@@ -6,6 +6,7 @@ import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
 import { useStore } from 'lib/store';
 import Tooltip from 'components/Tooltip';
 import useBlockReference from 'editor/backlinks/useBlockReference';
+import { useCurrentNote } from 'utils/useCurrentNote';
 import { ReadOnlyEditor } from '../ReadOnlyEditor';
 import EditorLeaf from './EditorLeaf';
 import ParagraphElement from './ParagraphElement';
@@ -24,7 +25,8 @@ export default function BlockRefElement(props: BlockRefElementProps) {
   const focused = useFocused();
 
   const blockReference = useBlockReference(element.blockId);
-  const onBlockRefClick = useOnNoteLinkClick();
+  const currentNote = useCurrentNote();
+  const onBlockRefClick = useOnNoteLinkClick(currentNote.id);
 
   const blockRefClassName = useMemo(
     () =>
@@ -54,7 +56,11 @@ export default function BlockRefElement(props: BlockRefElementProps) {
         onClick={(e) => {
           e.stopPropagation();
           if (blockReference) {
-            onBlockRefClick(e, blockReference.noteId, blockReference.path);
+            onBlockRefClick(
+              blockReference.noteId,
+              e.shiftKey,
+              blockReference.path
+            );
           }
         }}
         {...attributes}

--- a/components/editor/elements/NoteLinkElement.tsx
+++ b/components/editor/elements/NoteLinkElement.tsx
@@ -1,9 +1,7 @@
 import { ReactNode } from 'react';
 import { RenderElementProps, useFocused, useSelected } from 'slate-react';
-import Link from 'next/link';
 import { NoteLink } from 'types/slate';
 import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
-import { useStore } from 'lib/store';
 import Tooltip from 'components/Tooltip';
 import { useCurrentNote } from 'utils/useCurrentNote';
 
@@ -17,8 +15,8 @@ type NoteLinkElementProps = {
 export default function NoteLinkElement(props: NoteLinkElementProps) {
   const { className = '', element, children, attributes } = props;
   const currentNote = useCurrentNote();
-  const onNoteLinkClick = useOnNoteLinkClick(currentNote.id);
-  const isPageStackingOn = useStore((state) => state.isPageStackingOn);
+  const { onClick: onNoteLinkClick, defaultStackingBehavior } =
+    useOnNoteLinkClick(currentNote.id);
   const selected = useSelected();
   const focused = useFocused();
   const noteLinkClassName = `p-0.25 rounded text-primary-600 cursor-pointer select-none bg-gray-100 hover:bg-gray-200 active:bg-gray-300 dark:text-primary-400 dark:bg-gray-800 dark:hover:bg-gray-700 dark:active:bg-gray-600 ${className} ${
@@ -27,34 +25,19 @@ export default function NoteLinkElement(props: NoteLinkElementProps) {
 
   return (
     <Tooltip content={element.noteTitle} placement="bottom-start">
-      {isPageStackingOn ? (
-        <span
-          className={noteLinkClassName}
-          onClick={(e) => {
-            e.stopPropagation();
-            onNoteLinkClick(element.noteId, e.shiftKey);
-          }}
-          contentEditable={false}
-          {...attributes}
-        >
-          {element.customText ?? element.noteTitle}
-          {children}
-        </span>
-      ) : (
-        <span>
-          <Link href={`/app/note/${element.noteId}`}>
-            <a
-              className={noteLinkClassName}
-              contentEditable={false}
-              onClick={(e) => e.stopPropagation()}
-              {...attributes}
-            >
-              {element.customText ?? element.noteTitle}
-              {children}
-            </a>
-          </Link>
-        </span>
-      )}
+      <span
+        role="button"
+        className={noteLinkClassName}
+        onClick={(e) => {
+          e.stopPropagation();
+          onNoteLinkClick(element.noteId, defaultStackingBehavior(e));
+        }}
+        contentEditable={false}
+        {...attributes}
+      >
+        {element.customText ?? element.noteTitle}
+        {children}
+      </span>
     </Tooltip>
   );
 }

--- a/components/editor/elements/NoteLinkElement.tsx
+++ b/components/editor/elements/NoteLinkElement.tsx
@@ -5,6 +5,7 @@ import { NoteLink } from 'types/slate';
 import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
 import { useStore } from 'lib/store';
 import Tooltip from 'components/Tooltip';
+import { useCurrentNote } from 'utils/useCurrentNote';
 
 type NoteLinkElementProps = {
   element: NoteLink;
@@ -15,7 +16,8 @@ type NoteLinkElementProps = {
 
 export default function NoteLinkElement(props: NoteLinkElementProps) {
   const { className = '', element, children, attributes } = props;
-  const onNoteLinkClick = useOnNoteLinkClick();
+  const currentNote = useCurrentNote();
+  const onNoteLinkClick = useOnNoteLinkClick(currentNote.id);
   const isPageStackingOn = useStore((state) => state.isPageStackingOn);
   const selected = useSelected();
   const focused = useFocused();
@@ -30,7 +32,7 @@ export default function NoteLinkElement(props: NoteLinkElementProps) {
           className={noteLinkClassName}
           onClick={(e) => {
             e.stopPropagation();
-            onNoteLinkClick(e, element.noteId);
+            onNoteLinkClick(element.noteId, e.shiftKey);
           }}
           contentEditable={false}
           {...attributes}

--- a/components/editor/elements/NoteLinkElement.tsx
+++ b/components/editor/elements/NoteLinkElement.tsx
@@ -30,7 +30,7 @@ export default function NoteLinkElement(props: NoteLinkElementProps) {
           className={noteLinkClassName}
           onClick={(e) => {
             e.stopPropagation();
-            onNoteLinkClick(element.noteId);
+            onNoteLinkClick(e, element.noteId);
           }}
           contentEditable={false}
           {...attributes}

--- a/components/settings/EditorSettings.tsx
+++ b/components/settings/EditorSettings.tsx
@@ -10,9 +10,9 @@ export default function EditorSettings() {
       <div className="mb-4">
         <h1 className="text-lg font-medium">Page Stacking</h1>
         <p className="mt-2 text-sm text-gray-700">
-          If page stacking is on, clicking on note links will open the note on
-          the side, and shift-click will open a note by itself. If page stacking
-          is off, this behavior is reversed.
+          If page stacking is on, clicking a note link will open the note on the
+          side, and shift-clicking a note link will open the note by itself. If
+          page stacking is off, this behavior is reversed.
         </p>
       </div>
       <div className="flex items-center">

--- a/components/settings/EditorSettings.tsx
+++ b/components/settings/EditorSettings.tsx
@@ -1,0 +1,29 @@
+import { useStore } from 'lib/store';
+import Toggle from 'components/Toggle';
+
+export default function EditorSettings() {
+  const isPageStackingOn = useStore((state) => state.isPageStackingOn);
+  const setIsPageStackingOn = useStore((state) => state.setIsPageStackingOn);
+
+  return (
+    <div className="flex-1 p-6 overflow-y-auto dark:bg-gray-800 dark:text-gray-100">
+      <div className="mb-4">
+        <h1 className="text-lg font-medium">Page Stacking</h1>
+        <p className="mt-2 text-sm text-gray-700">
+          If page stacking is on, clicking on note links will open the note on
+          the side, and shift-click will open a note by itself. If page stacking
+          is off, this behavior is reversed.
+        </p>
+      </div>
+      <div className="flex items-center">
+        <span className="text-sm text-gray-600 dark:text-gray-200">Off</span>
+        <Toggle
+          className="mx-2"
+          isChecked={isPageStackingOn}
+          setIsChecked={setIsPageStackingOn}
+        />
+        <span className="text-sm text-gray-600 dark:text-gray-200">On</span>
+      </div>
+    </div>
+  );
+}

--- a/components/settings/SettingsModal.tsx
+++ b/components/settings/SettingsModal.tsx
@@ -1,12 +1,14 @@
 import { useMemo, useState } from 'react';
-import { IconBrightnessHalf, IconCreditCard } from '@tabler/icons';
+import { IconBrightnessHalf, IconCreditCard, IconPencil } from '@tabler/icons';
 import useHotkeys from 'utils/useHotkeys';
 import SidebarItem from '../sidebar/SidebarItem';
 import Billing from './Billing';
 import Appearance from './Appearance';
+import EditorSettings from './EditorSettings';
 
 enum SettingsTab {
   Appearance = 'appearance',
+  Editor = 'editor',
   Billing = 'billing',
 }
 
@@ -44,6 +46,7 @@ export default function SettingsModal(props: Props) {
             setCurrentTab={setCurrentTab}
           />
           {currentTab === SettingsTab.Appearance ? <Appearance /> : null}
+          {currentTab === SettingsTab.Editor ? <EditorSettings /> : null}
           {currentTab === SettingsTab.Billing ? <Billing /> : null}
         </div>
       </div>
@@ -76,6 +79,21 @@ const SettingsModalSidebar = (props: SettingsModalSidebarProps) => {
             className="mr-1 text-gray-800 dark:text-gray-200"
           />
           <span>Appearance</span>
+        </button>
+      </SidebarItem>
+      <SidebarItem
+        className="flex"
+        isHighlighted={currentTab === SettingsTab.Editor}
+      >
+        <button
+          className="flex items-center flex-1 px-4 py-1 overflow-hidden overflow-ellipsis whitespace-nowrap"
+          onClick={() => setCurrentTab(SettingsTab.Editor)}
+        >
+          <IconPencil
+            size={18}
+            className="mr-1 text-gray-800 dark:text-gray-200"
+          />
+          <span>Editor</span>
         </button>
       </SidebarItem>
       <SidebarItem

--- a/components/sidebar/SidebarNoteLink.tsx
+++ b/components/sidebar/SidebarNoteLink.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { IconCaretRight } from '@tabler/icons';
 import { useStore } from 'lib/store';
 import { isMobile } from 'utils/device';
+import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
 import SidebarItem from './SidebarItem';
 import SidebarNoteLinkDropdown from './SidebarNoteLinkDropdown';
 import { FlattenedNoteTreeItem } from './SidebarNotesTree';
@@ -28,6 +29,10 @@ const SidebarNoteLink = (
 
   const note = useStore((state) => state.notes[node.id]);
   const setIsSidebarOpen = useStore((state) => state.setIsSidebarOpen);
+  const lastOpenNoteId = useStore(
+    (state) => state.openNoteIds[state.openNoteIds.length - 1]
+  );
+  const onNoteLinkClick = useOnNoteLinkClick(lastOpenNoteId);
 
   // We add 16px for every level of nesting, plus 8px base padding
   const leftPadding = useMemo(() => node.depth * 16 + 8, [node.depth]);
@@ -43,7 +48,11 @@ const SidebarNoteLink = (
       <Link href={`/app/note/${note.id}`}>
         <a
           className="flex items-center flex-1 px-2 py-1 overflow-hidden overflow-ellipsis whitespace-nowrap"
-          onClick={() => {
+          onClick={(e) => {
+            if (e.shiftKey) {
+              e.preventDefault();
+              onNoteLinkClick(note.id, false);
+            }
             if (isMobile()) {
               setIsSidebarOpen(false);
             }

--- a/components/sidebar/SidebarNoteLink.tsx
+++ b/components/sidebar/SidebarNoteLink.tsx
@@ -1,7 +1,7 @@
 import { ForwardedRef, forwardRef, HTMLAttributes, memo, useMemo } from 'react';
 import Link from 'next/link';
 import { IconCaretRight } from '@tabler/icons';
-import { useStore } from 'lib/store';
+import { store, useStore } from 'lib/store';
 import { isMobile } from 'utils/device';
 import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
 import SidebarItem from './SidebarItem';
@@ -51,7 +51,9 @@ const SidebarNoteLink = (
           onClick={(e) => {
             if (e.shiftKey) {
               e.preventDefault();
-              onNoteLinkClick(note.id, false);
+              // If page stacking is on, we want to keep the default behavior.
+              // If page stacking is off, we want to reverse the default behavior.
+              onNoteLinkClick(note.id, !store.getState().isPageStackingOn);
             }
             if (isMobile()) {
               setIsSidebarOpen(false);

--- a/components/sidebar/SidebarNoteLink.tsx
+++ b/components/sidebar/SidebarNoteLink.tsx
@@ -1,7 +1,6 @@
 import { ForwardedRef, forwardRef, HTMLAttributes, memo, useMemo } from 'react';
-import Link from 'next/link';
 import { IconCaretRight } from '@tabler/icons';
-import { store, useStore } from 'lib/store';
+import { useStore } from 'lib/store';
 import { isMobile } from 'utils/device';
 import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
 import SidebarItem from './SidebarItem';
@@ -32,7 +31,7 @@ const SidebarNoteLink = (
   const lastOpenNoteId = useStore(
     (state) => state.openNoteIds[state.openNoteIds.length - 1]
   );
-  const onNoteLinkClick = useOnNoteLinkClick(lastOpenNoteId);
+  const { onClick: onNoteLinkClick } = useOnNoteLinkClick(lastOpenNoteId);
 
   // We add 16px for every level of nesting, plus 8px base padding
   const leftPadding = useMemo(() => node.depth * 16 + 8, [node.depth]);
@@ -45,44 +44,39 @@ const SidebarNoteLink = (
       style={style}
       {...otherProps}
     >
-      <Link href={`/app/note/${note.id}`}>
-        <a
-          className="flex items-center flex-1 px-2 py-1 overflow-hidden overflow-ellipsis whitespace-nowrap"
+      <div
+        role="button"
+        className="flex items-center flex-1 px-2 py-1 overflow-hidden overflow-ellipsis whitespace-nowrap"
+        onClick={(e) => {
+          e.preventDefault();
+          onNoteLinkClick(note.id, e.shiftKey);
+          if (isMobile()) {
+            setIsSidebarOpen(false);
+          }
+        }}
+        style={{ paddingLeft: `${leftPadding}px` }}
+        draggable={false}
+      >
+        <button
+          className="p-1 mr-1 rounded hover:bg-gray-300 active:bg-gray-400 dark:hover:bg-gray-600 dark:active:bg-gray-500"
           onClick={(e) => {
-            if (e.shiftKey) {
-              e.preventDefault();
-              // If page stacking is on, we want to keep the default behavior.
-              // If page stacking is off, we want to reverse the default behavior.
-              onNoteLinkClick(note.id, !store.getState().isPageStackingOn);
-            }
-            if (isMobile()) {
-              setIsSidebarOpen(false);
-            }
+            e.preventDefault();
+            e.stopPropagation();
+            onArrowClick?.();
           }}
-          style={{ paddingLeft: `${leftPadding}px` }}
-          draggable={false}
         >
-          <button
-            className="p-1 mr-1 rounded hover:bg-gray-300 active:bg-gray-400 dark:hover:bg-gray-600 dark:active:bg-gray-500"
-            onClick={(e) => {
-              e.preventDefault();
-              e.stopPropagation();
-              onArrowClick?.();
-            }}
-          >
-            <IconCaretRight
-              className={`flex-shrink-0 text-gray-500 dark:text-gray-100 transform transition-transform ${
-                !node.collapsed ? 'rotate-90' : ''
-              }`}
-              size={16}
-              fill="currentColor"
-            />
-          </button>
-          <span className="overflow-hidden overflow-ellipsis whitespace-nowrap">
-            {note.title}
-          </span>
-        </a>
-      </Link>
+          <IconCaretRight
+            className={`flex-shrink-0 text-gray-500 dark:text-gray-100 transform transition-transform ${
+              !node.collapsed ? 'rotate-90' : ''
+            }`}
+            size={16}
+            fill="currentColor"
+          />
+        </button>
+        <span className="overflow-hidden overflow-ellipsis whitespace-nowrap">
+          {note.title}
+        </span>
+      </div>
       <SidebarNoteLinkDropdown
         note={note}
         className="hidden group-hover:block"

--- a/editor/useOnNoteLinkClick.ts
+++ b/editor/useOnNoteLinkClick.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { MouseEvent, useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { Path } from 'slate';
 import { useCurrentNote } from 'utils/useCurrentNote';
@@ -15,7 +15,7 @@ export default function useOnNoteLinkClick() {
   const isPageStackingOn = useStore((state) => state.isPageStackingOn);
 
   const onClick = useCallback(
-    (noteId: string, highlightedPath?: Path) => {
+    (e: MouseEvent, noteId: string, highlightedPath?: Path) => {
       /**
        * If the note is already open, scroll it into view
        */
@@ -64,7 +64,10 @@ export default function useOnNoteLinkClick() {
       );
 
       // Open new note (either as a stacked note or as a new page)
-      if (isPageStackingOn) {
+      if (
+        (isPageStackingOn && !e.shiftKey) ||
+        (!isPageStackingOn && e.shiftKey)
+      ) {
         const hash = highlightedPath
           ? `${newNoteIndex}-${highlightedPath}`
           : undefined;

--- a/editor/useOnNoteLinkClick.ts
+++ b/editor/useOnNoteLinkClick.ts
@@ -1,21 +1,23 @@
-import { MouseEvent, useCallback } from 'react';
+import { useCallback } from 'react';
 import { useRouter } from 'next/router';
 import { Path } from 'slate';
-import { useCurrentNote } from 'utils/useCurrentNote';
 import { useStore } from 'lib/store';
 import { queryParamToArray } from 'utils/url';
 
-export default function useOnNoteLinkClick() {
+export default function useOnNoteLinkClick(currentNoteId: string) {
   const router = useRouter();
   const {
     query: { stack: stackQuery },
   } = router;
-  const currentNote = useCurrentNote();
   const openNoteIds = useStore((state) => state.openNoteIds);
   const isPageStackingOn = useStore((state) => state.isPageStackingOn);
 
   const onClick = useCallback(
-    (e: MouseEvent, noteId: string, highlightedPath?: Path) => {
+    (
+      noteId: string,
+      reverseDefaultBehavior = false,
+      highlightedPath?: Path
+    ) => {
       /**
        * If the note is already open, scroll it into view
        */
@@ -47,7 +49,7 @@ export default function useOnNoteLinkClick() {
        * If the note is not open, add it to the open notes
        */
       const currentNoteIndex = openNoteIds.findIndex(
-        (openNoteId) => openNoteId === currentNote.id
+        (openNoteId) => openNoteId === currentNoteId
       );
       if (currentNoteIndex < 0) {
         return;
@@ -65,8 +67,8 @@ export default function useOnNoteLinkClick() {
 
       // Open new note (either as a stacked note or as a new page)
       if (
-        (isPageStackingOn && !e.shiftKey) ||
-        (!isPageStackingOn && e.shiftKey)
+        (isPageStackingOn && !reverseDefaultBehavior) ||
+        (!isPageStackingOn && reverseDefaultBehavior)
       ) {
         const hash = highlightedPath
           ? `${newNoteIndex}-${highlightedPath}`
@@ -89,7 +91,7 @@ export default function useOnNoteLinkClick() {
         });
       }
     },
-    [router, openNoteIds, currentNote, stackQuery, isPageStackingOn]
+    [router, openNoteIds, currentNoteId, stackQuery, isPageStackingOn]
   );
 
   return onClick;

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -228,7 +228,13 @@ export const store = createVanilla<Store>(
       name: 'notabase-storage',
       version: 1,
       getStorage: () => storage,
-      whitelist: ['openNoteIds', 'isSidebarOpen', 'noteSort', 'darkMode'],
+      whitelist: [
+        'openNoteIds',
+        'isSidebarOpen',
+        'noteSort',
+        'darkMode',
+        'isPageStackingOn',
+      ],
     }
   )
 );

--- a/pages/changelog.tsx
+++ b/pages/changelog.tsx
@@ -27,6 +27,12 @@ export default function Changelog() {
           .
         </p>
         <ChangelogBlock
+          title="September 17, 2021"
+          features={[
+            'Page stacking can now be turned on and off, and the opposite behavior can be achieved by shift-clicking',
+          ]}
+        />
+        <ChangelogBlock
           title="September 16, 2021"
           features={['Add checklists', 'Update block menu UI']}
           bugFixes={[

--- a/utils/useIsMounted.ts
+++ b/utils/useIsMounted.ts
@@ -1,0 +1,17 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+function useIsMounted() {
+  const isMounted = useRef(false);
+
+  useEffect(() => {
+    isMounted.current = true;
+
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  return useCallback(() => isMounted.current, []);
+}
+
+export default useIsMounted;


### PR DESCRIPTION
This PR:
- Adds page stacking as a setting
- Persists your selected option for page stacking
- Adds shift-click to select the opposite behavior for page stacking

For example, by default page stacking is on. If you click on a note link, it will open on the side. If you shift click a note link, it will open in its own page. If page stacking is off, this behavior is reversed.

For note links in the sidebar, clicking will always open the note in its own page, and shift clicking will always open the note on the side.