### PR TITLE
Fix settings not getting persisted on mobile

### DIFF
--- a/components/AppLayout.tsx
+++ b/components/AppLayout.tsx
@@ -169,12 +169,21 @@ export default function AppLayout(props: Props) {
   const updateNote = useStore((state) => state.updateNote);
   const deleteNote = useStore((state) => state.deleteNote);
 
+  const hasHydrated = useStore((state) => state._hasHydrated);
   useEffect(() => {
-    if (isMobile()) {
+    // If the user is mobile, the persisted data has been hydrated, and there are no open note ids (a proxy for the first load),
+    // change the initial values of isSidebarOpen and isPageStackingOn to better suit mobile devices
+    // We need to wait until after hydration because otherwise the persisted state gets overridden and thrown away
+    // After https://github.com/pmndrs/zustand/issues/562 is fixed, we can change this
+    if (
+      isMobile() &&
+      hasHydrated &&
+      store.getState().openNoteIds.length === 0
+    ) {
       setIsSidebarOpen(false);
       setIsPageStackingOn(false);
     }
-  }, [setIsSidebarOpen, setIsPageStackingOn]);
+  }, [setIsSidebarOpen, setIsPageStackingOn, hasHydrated]);
 
   useEffect(() => {
     if (!user) {

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -21,6 +21,12 @@ const immer =
   (set, get, api) =>
     config((fn) => set(produce<T>(fn)), get, api);
 
+localforage.config({
+  name: 'notabase',
+  version: 1.0,
+  storeName: 'user_data',
+});
+
 const storage: StateStorage = {
   getItem: async (name: string): Promise<string | null> => {
     return await localforage.getItem(name);

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -54,6 +54,7 @@ export type BillingDetails =
     };
 
 export type Store = {
+  _hasHydrated: boolean; // TODO: temporary until https://github.com/pmndrs/zustand/issues/562 gets fixed
   billingDetails: BillingDetails;
   setBillingDetails: Setter<BillingDetails>;
   notes: Notes;
@@ -101,6 +102,7 @@ export const setter =
 export const store = createVanilla<Store>(
   persist(
     immer((set) => ({
+      _hasHydrated: false,
       /**
        * The billing details of the current user
        */
@@ -241,6 +243,9 @@ export const store = createVanilla<Store>(
         'darkMode',
         'isPageStackingOn',
       ],
+      onRehydrateStorage: () => () => {
+        useStore.setState({ _hasHydrated: true });
+      },
     }
   )
 );

--- a/pages/changelog.tsx
+++ b/pages/changelog.tsx
@@ -27,6 +27,12 @@ export default function Changelog() {
           .
         </p>
         <ChangelogBlock
+          title="September 20, 2021"
+          bugFixes={[
+            'Fix bug on mobile devices where settings are not being persisted',
+          ]}
+        />
+        <ChangelogBlock
           title="September 18, 2021"
           bugFixes={[
             'Fix bug where note tree can have nonexistent note ids inside',


### PR DESCRIPTION
This PR fixes settings not getting persisted on mobile. It also updates the location of the IndexedDB database in which we're storing data. This will likely mean that we're throwing away currently persisted settings, but it's okay because we're not persisting anything too important right now.