### PR TITLE
Fixed updating note_tree after deleting notes

### DIFF
--- a/lib/api/deleteNote.ts
+++ b/lib/api/deleteNote.ts
@@ -2,15 +2,16 @@ import { store } from 'lib/store';
 import supabase from 'lib/supabase';
 import type { Note, User } from 'types/supabase';
 
-export default async function deleteNote(id: string) {
+export default async function deleteNote(userId: string, noteId: string) {
   // Update note titles in sidebar
-  store.getState().deleteNote(id);
+  store.getState().deleteNote(noteId);
 
-  const response = await supabase.from<Note>('notes').delete().eq('id', id);
+  const response = await supabase.from<Note>('notes').delete().eq('id', noteId);
 
   await supabase
     .from<User>('users')
-    .update({ note_tree: store.getState().noteTree });
+    .update({ note_tree: store.getState().noteTree })
+    .eq('id', userId);
 
   return response;
 }

--- a/lib/api/upsertNote.ts
+++ b/lib/api/upsertNote.ts
@@ -22,7 +22,8 @@ export default async function upsertNote(note: NoteUpsert) {
     store.getState().upsertNote(data);
     await supabase
       .from<User>('users')
-      .update({ note_tree: store.getState().noteTree });
+      .update({ note_tree: store.getState().noteTree })
+      .eq('id', note.user_id);
   } else if (error) {
     console.error(error);
   }

--- a/utils/useDeleteNote.ts
+++ b/utils/useDeleteNote.ts
@@ -3,9 +3,11 @@ import { useRouter } from 'next/router';
 import deleteBacklinks from 'editor/backlinks/deleteBacklinks';
 import deleteNote from 'lib/api/deleteNote';
 import { store, useStore } from 'lib/store';
+import { useAuth } from './useAuth';
 
 export default function useDeleteNote(noteId: string) {
   const router = useRouter();
+  const { user } = useAuth();
 
   const openNoteIds = useStore((state) => state.openNoteIds);
 
@@ -32,9 +34,13 @@ export default function useDeleteNote(noteId: string) {
       }
     }
 
-    await deleteNote(noteId);
+    if (!user) {
+      return;
+    }
+
+    await deleteNote(user.id, noteId);
     await deleteBacklinks(noteId);
-  }, [router, noteId, openNoteIds]);
+  }, [router, user, noteId, openNoteIds]);
 
   return onDeleteClick;
 }


### PR DESCRIPTION
Hi! First of all, thank you for making notabase, I really enjoy using it! I noticed that in some cases the sidebar does not update correctly after notes are deleted. This is because after deleting notes, supabase is trying to change the users table without a `WHERE` condition. This seems to be (fortunately!) not allowed:

![image](https://user-images.githubusercontent.com/14850833/169010740-81a5acc2-634d-4a87-a120-ae89eaacf39b.png)

I have tried to fix the relevant supabase requests. I hope this helps you!