### PR TITLE
Disable sentry if not configured

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -16,6 +16,9 @@ const SentryWebpackPluginOptions = {
   //   release, url, org, project, authToken, configFile, stripPrefix,
   //   urlPrefix, include, ignore
 
+  // Disable sentry if not configured.
+  dryRun: process.env.NEXT_PUBLIC_SENTRY_DSN === '',
+
   silent: true, // Suppresses all logs
   // For all available options, see:
   // https://github.com/getsentry/sentry-webpack-plugin#options.


### PR DESCRIPTION
Self-hosters might not use sentry. This PR disables sentry if the environment variable `NEXT_PUBLIC_SENTRY_DSN` is not set.

I am not completely sure if `dryRun = true` is the best way to disable sentry. Switching the [variable `enabled` in `sentry.{client,server}.config.js`](https://github.com/churichard/notabase/blob/3f554c3eb85f2a5171267cb01b7175f53c64d89f/sentry.client.config.js#L13) based on existance of `NEXT_PUBLIC_SENTRY_DSN` does not work, because an empty [`dsn` variable](https://github.com/churichard/notabase/blob/3f554c3eb85f2a5171267cb01b7175f53c64d89f/sentry.client.config.js#L10) fails a URL parsing check of the sentry SDK. If the `enabled` variable should be used, an additional environment variable like `SENTRY_ENABLED` could be introduced to toggle `enabled` variable, while keeping a URL in `NEXT_PUBLIC_SENTRY_DSN`.