### PR TITLE
Update slate-react to 0.67, treat value as initial value

### DIFF
--- a/editor/transforms.ts
+++ b/editor/transforms.ts
@@ -1,5 +1,4 @@
-import type { Editor, Path } from 'slate';
-import { Transforms } from 'slate';
+import { Editor, Location, Node, Path, Point, Transforms } from 'slate';
 
 // Deletes `length` characters at the specified path and offset
 export const deleteText = (
@@ -17,4 +16,43 @@ export const deleteText = (
     focus: { path, offset },
   };
   Transforms.delete(editor, { at: range });
+};
+
+/**
+ * resetNodes resets the value of the editor.
+ * It should be noted that passing the `at` parameter may cause a "Cannot resolve a DOM point from Slate point" error.
+ */
+export const resetNodes = (
+  editor: Editor,
+  options: {
+    nodes?: Node | Node[];
+    at?: Location;
+  } = {}
+): void => {
+  const children = [...editor.children];
+
+  children.forEach((node) =>
+    editor.apply({ type: 'remove_node', path: [0], node })
+  );
+
+  if (options.nodes) {
+    const nodes = Node.isNode(options.nodes) ? [options.nodes] : options.nodes;
+
+    nodes.forEach((node, i) =>
+      editor.apply({ type: 'insert_node', path: [i], node: node })
+    );
+  }
+
+  const point =
+    options.at && Point.isPoint(options.at)
+      ? options.at
+      : Editor.end(editor, []);
+
+  if (point) {
+    try {
+      Transforms.select(editor, point);
+    } catch (e) {
+      // Do nothing. Selection was not able to be restored.
+    }
+  }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "slate": "^0.66.5",
         "slate-history": "^0.66.0",
         "slate-hyperscript": "^0.67.0",
-        "slate-react": "^0.66.7",
+        "slate-react": "^0.67.0",
         "stripe": "^9.2.0",
         "tailwindcss": "^3.0.24",
         "unified": "^10.1.2",
@@ -13599,9 +13599,9 @@
       }
     },
     "node_modules/slate-react": {
-      "version": "0.66.7",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.66.7.tgz",
-      "integrity": "sha512-M0MGCnANdjRZCKGY9cvqHBR/WJ+/4SMIvBvEx4UJ5ycx9uNkDVPdpsyvwDKOpmsJuzZ1DH+34YrpxT7RnQyp1Q==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.67.0.tgz",
+      "integrity": "sha512-aJDqDskN2Ny1Q2bUFmM9qG000BbDLkA8+pIsrK9Z30glmS7je+KWoR29zdHe2s/fuKRLVayxcvs+q1VQzc1dfw==",
       "dependencies": {
         "@types/is-hotkey": "^0.1.1",
         "@types/lodash": "^4.14.149",
@@ -25221,9 +25221,9 @@
       }
     },
     "slate-react": {
-      "version": "0.66.7",
-      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.66.7.tgz",
-      "integrity": "sha512-M0MGCnANdjRZCKGY9cvqHBR/WJ+/4SMIvBvEx4UJ5ycx9uNkDVPdpsyvwDKOpmsJuzZ1DH+34YrpxT7RnQyp1Q==",
+      "version": "0.67.0",
+      "resolved": "https://registry.npmjs.org/slate-react/-/slate-react-0.67.0.tgz",
+      "integrity": "sha512-aJDqDskN2Ny1Q2bUFmM9qG000BbDLkA8+pIsrK9Z30glmS7je+KWoR29zdHe2s/fuKRLVayxcvs+q1VQzc1dfw==",
       "requires": {
         "@types/is-hotkey": "^0.1.1",
         "@types/lodash": "^4.14.149",

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "slate": "^0.66.5",
     "slate-history": "^0.66.0",
     "slate-hyperscript": "^0.67.0",
-    "slate-react": "^0.66.7",
+    "slate-react": "^0.67.0",
     "stripe": "^9.2.0",
     "tailwindcss": "^3.0.24",
     "unified": "^10.1.2",


### PR DESCRIPTION
Slate 0.67 has a major change which treats the `value` passed in as an initial value. This PR updates Notabase's code such that we account for this change and so that external updates which update the editor value still work correctly.