### PR TITLE
Add supabase config and cypress github action

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -18,6 +18,8 @@ jobs:
         cache: 'npm'
 
     - uses: supabase/setup-cli@v1.1.1
+      with:
+        version: latest
     - run: supabase start
     - run: supabase status -o env --override-name api.url=NEXT_PUBLIC_SUPABASE_URL --override-name auth.anon_key=NEXT_PUBLIC_SUPABASE_KEY --override-name auth.service_role_key=SUPABASE_SERVICE_KEY | tee .env.local .env.test
 

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -19,6 +19,7 @@ jobs:
 
     - uses: supabase/setup-cli@v1.1.1
     - run: supabase start
+    - run: supabase status -o env --override-name api.url=NEXT_PUBLIC_SUPABASE_URL --override-name auth.anon_key=NEXT_PUBLIC_SUPABASE_KEY --override-name auth.service_role_key=SUPABASE_SERVICE_KEY | tee .env.local .env.test
 
     - name: Cypress run
       uses: cypress-io/github-action@v4.2.0

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -1,0 +1,27 @@
+name: cypress tests
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest  
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 16.x
+        cache: 'npm'
+
+    - uses: supabase/setup-cli@v1.1.1
+    - run: supabase start
+
+    - name: Cypress run
+      uses: cypress-io/github-action@v4.2.0
+      with:
+        build: npm run build
+        start: npm start

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
       return require('./cypress/plugins/index.js')(on, config);
     },
     baseUrl: 'http://localhost:3000',
+    video: false,
   },
 });

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,0 +1,3 @@
+# Supabase
+.branches
+.temp

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -1,0 +1,69 @@
+# A string used to distinguish different Supabase projects on the same host. Defaults to the working
+# directory name when running `supabase init`.
+project_id = "notabase"
+
+[api]
+# Port to use for the API URL.
+port = 54321
+# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# endpoints. public and storage are always included.
+schemas = []
+# Extra schemas to add to the search_path of every request.
+extra_search_path = ["extensions"]
+# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# for accidental or malicious requests.
+max_rows = 1000
+
+[db]
+# Port to use for the local database URL.
+port = 54322
+# The database major version to use. This has to be the same as your remote database's. Run `SHOW
+# server_version;` on the remote database to check.
+major_version = 12
+
+[studio]
+# Port to use for Supabase Studio.
+port = 54323
+
+# Email testing server. Emails sent with the local dev setup are not actually sent - rather, they
+# are monitored, and you can view the emails that would have been sent from the web interface.
+[inbucket]
+# Port to use for the email testing server web interface.
+port = 54324
+smtp_port = 54325
+pop3_port = 54326
+
+[storage]
+# The maximum file size allowed (e.g. "5MB", "500KB").
+file_size_limit = "50MiB"
+
+[auth]
+# The base URL of your website. Used as an allow-list for redirects and for constructing URLs used
+# in emails.
+site_url = "http://localhost:3000"
+# A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
+additional_redirect_urls = ["http://localhost:3000/app", "http://localhost:3000/resetting-password"]
+# How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 seconds (one
+# week).
+jwt_expiry = 3600
+# Allow/disallow new user signups to your project.
+enable_signup = true
+
+[auth.email]
+# Allow/disallow new user signups via email to your project.
+enable_signup = true
+# If enabled, a user will be required to confirm any email change on both the old, and new email
+# addresses. If disabled, only the new email is required to confirm.
+double_confirm_changes = false
+# If enabled, users need to confirm their email address before signing in.
+enable_confirmations = true
+
+# Use an external OAuth provider. The full list of providers are: `apple`, `azure`, `bitbucket`,
+# `discord`, `facebook`, `github`, `gitlab`, `google`, `twitch`, `twitter`, `slack`, `spotify`.
+[auth.external.apple]
+enabled = false
+client_id = ""
+secret = ""
+# Overrides the default auth provider URL. Used to support self-hosted gitlab, single-tenant Azure,
+# or any other third-party OIDC providers.
+url = ""

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -19,7 +19,7 @@ max_rows = 1000
 port = 54322
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
-major_version = 12
+major_version = 14
 
 [studio]
 # Port to use for Supabase Studio.


### PR DESCRIPTION
This PR adds a basic Supabase config (for running Supabase using the CLI) and a GitHub Action for running Cypress tests automatically in CI.