### PR TITLE
Add linked reference tests

### DIFF
--- a/components/editor/Editor.tsx
+++ b/components/editor/Editor.tsx
@@ -315,6 +315,7 @@ function Editor(props: Props) {
       <TagAutocompletePopover />
       <Editable
         className={`overflow-hidden placeholder-gray-300 ${className}`}
+        data-testid="note-editor"
         renderElement={renderElement}
         renderLeaf={EditorLeaf}
         placeholder="Start typing here…"

--- a/components/editor/NoteHeader.tsx
+++ b/components/editor/NoteHeader.tsx
@@ -139,6 +139,7 @@ export default function NoteHeader() {
                 ref={menuButtonRef}
                 className={buttonClassName}
                 title="Options (export, import, etc.)"
+                data-testid="note-menu-button"
               >
                 <Tooltip content="Options (export, import, etc.)">
                   <span className="flex items-center justify-center w-8 h-8">
@@ -150,6 +151,7 @@ export default function NoteHeader() {
                 <Portal>
                   <Menu.Items
                     ref={setPopperElement}
+                    data-testid="note-menu-button-dropdown"
                     className="z-10 w-56 overflow-hidden bg-white rounded shadow-popover dark:bg-gray-800 focus:outline-none"
                     static
                     style={styles.popper}

--- a/components/editor/Title.tsx
+++ b/components/editor/Title.tsx
@@ -32,6 +32,7 @@ function Title(props: Props) {
     <>
       <div
         ref={titleRef}
+        data-testid="note-title"
         className={`title text-3xl md:text-4xl font-semibold border-none focus:outline-none p-0 leading-tight cursor-text ${className}`}
         role="textbox"
         placeholder="Untitled"

--- a/components/editor/Title.tsx
+++ b/components/editor/Title.tsx
@@ -32,8 +32,8 @@ function Title(props: Props) {
     <>
       <div
         ref={titleRef}
-        data-testid="note-title"
         className={`title text-3xl md:text-4xl font-semibold border-none focus:outline-none p-0 leading-tight cursor-text ${className}`}
+        data-testid="note-title"
         role="textbox"
         placeholder="Untitled"
         onKeyPress={(event) => {

--- a/components/editor/backlinks/BacklinkNoteBranch.tsx
+++ b/components/editor/backlinks/BacklinkNoteBranch.tsx
@@ -5,11 +5,10 @@ import { useCurrentNote } from 'utils/useCurrentNote';
 
 type BacklinkNoteBranchProps = {
   backlink: Backlink;
-  isLinked: boolean;
 };
 
 const BacklinkNoteBranch = (props: BacklinkNoteBranchProps) => {
-  const { backlink, isLinked } = props;
+  const { backlink } = props;
   const currentNote = useCurrentNote();
   const { onClick: onNoteLinkClick, defaultStackingBehavior } =
     useOnNoteLinkClick(currentNote.id);
@@ -17,7 +16,7 @@ const BacklinkNoteBranch = (props: BacklinkNoteBranchProps) => {
   return (
     <button
       className="py-1 link"
-      data-testid={isLinked ? 'linked-reference' : 'unlinked-reference'}
+      data-testid={backlink.type + '-reference'}
       onClick={(e) => {
         e.stopPropagation();
         onNoteLinkClick(backlink.id, defaultStackingBehavior(e));

--- a/components/editor/backlinks/BacklinkNoteBranch.tsx
+++ b/components/editor/backlinks/BacklinkNoteBranch.tsx
@@ -5,10 +5,11 @@ import { useCurrentNote } from 'utils/useCurrentNote';
 
 type BacklinkNoteBranchProps = {
   backlink: Backlink;
+  isLinked: boolean;
 };
 
 const BacklinkNoteBranch = (props: BacklinkNoteBranchProps) => {
-  const { backlink } = props;
+  const { backlink, isLinked } = props;
   const currentNote = useCurrentNote();
   const { onClick: onNoteLinkClick, defaultStackingBehavior } =
     useOnNoteLinkClick(currentNote.id);
@@ -16,6 +17,7 @@ const BacklinkNoteBranch = (props: BacklinkNoteBranchProps) => {
   return (
     <button
       className="py-1 link"
+      data-testid={isLinked ? 'linked-reference' : 'unlinked-reference'}
       onClick={(e) => {
         e.stopPropagation();
         onNoteLinkClick(backlink.id, defaultStackingBehavior(e));

--- a/components/editor/elements/NoteLinkElement.tsx
+++ b/components/editor/elements/NoteLinkElement.tsx
@@ -32,8 +32,8 @@ export default function NoteLinkElement(props: NoteLinkElementProps) {
     <Tooltip content={element.noteTitle} placement="bottom-start">
       <span
         role="button"
-        data-testid={'note-link-element-' + element.noteTitle}
         className={noteLinkClassName}
+        data-testid="note-link-element"
         onClick={(e) => {
           e.stopPropagation();
           onNoteLinkClick(element.noteId, defaultStackingBehavior(e));

--- a/components/editor/elements/NoteLinkElement.tsx
+++ b/components/editor/elements/NoteLinkElement.tsx
@@ -32,6 +32,7 @@ export default function NoteLinkElement(props: NoteLinkElementProps) {
     <Tooltip content={element.noteTitle} placement="bottom-start">
       <span
         role="button"
+        data-testid={'note-link-element-' + element.noteTitle}
         className={noteLinkClassName}
         onClick={(e) => {
           e.stopPropagation();

--- a/components/sidebar/SidebarNoteLink.tsx
+++ b/components/sidebar/SidebarNoteLink.tsx
@@ -81,7 +81,10 @@ const SidebarNoteLink = (
             fill="currentColor"
           />
         </button>
-        <span className="overflow-hidden overflow-ellipsis whitespace-nowrap">
+        <span
+          data-testid={'sidebar-note-link-' + note.title}
+          className="overflow-hidden overflow-ellipsis whitespace-nowrap"
+        >
           {note.title}
         </span>
       </div>

--- a/components/sidebar/SidebarNoteLink.tsx
+++ b/components/sidebar/SidebarNoteLink.tsx
@@ -82,8 +82,8 @@ const SidebarNoteLink = (
           />
         </button>
         <span
-          data-testid={'sidebar-note-link-' + note.title}
           className="overflow-hidden overflow-ellipsis whitespace-nowrap"
+          data-testid="sidebar-note-link"
         >
           {note.title}
         </span>

--- a/cypress/fixtures/notes.json
+++ b/cypress/fixtures/notes.json
@@ -1,0 +1,335 @@
+[
+  {
+    "id": "bea6ab7b-b4bd-4239-ba38-f170562ff7a9",
+    "title": "001=>111",
+    "content": [{
+      "type": "paragraph",
+      "children": [
+        {
+        "text": "Link to "
+        },
+        {
+        "id": "23d66660-57a9-4078-b1d0-58edf9aa0562",
+        "type": "note-link",
+        "noteId": "7f301e32-3d96-4cd4-b502-58de01018370",
+        "children": [
+            {
+            "text": "111"
+            }
+        ],
+        "noteTitle": "111"
+        },
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "44936756-b0ad-4c6e-a792-4bb4597c1c1d",
+    "title": "112=>111",
+    "content": [{ 
+      "type": "paragraph",
+      "children": [
+        {
+        "text": "Link to "
+        },
+        {
+        "id": "a498cd87-2879-48e5-baa9-74bc0de7458e",
+        "type": "note-link",
+        "noteId": "7d0148ad-6e29-4118-8231-32195b471917",
+        "children": [
+            {
+            "text": "111=>112"
+            }
+        ],
+        "noteTitle": "111=>112"
+        },
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "bcfb64cf-67ea-40be-aab6-60121da26e16",
+    "title": "001=>211",
+    "content": [{ 
+      "type": "paragraph",
+      "children": [
+        {
+        "text": "Link to "
+        },
+        {
+        "id": "38c013d1-288d-443e-b189-35e71be5010e",
+        "type": "note-link",
+        "noteId": "c8207f92-b927-4ba5-b1bb-8828723999f3",
+        "children": [
+            {
+            "text": "211"
+            }
+        ],
+        "noteTitle": "211"
+        },
+        {
+        "text": "Link to "
+        },
+        {
+        "id": "38c013d1-288d-443e-b189-35e71be5010e",
+        "type": "note-link",
+        "noteId": "c8207f92-b927-4ba5-b1bb-8828723999f3",
+        "children": [
+            {
+            "text": "211"
+            }
+        ],
+        "noteTitle": "211"
+        }
+      ]
+    }]
+  },
+  {
+    "id": "f0ffa7b9-794d-4b52-8404-8c70ef7d2e7f",
+    "title": "001=>112",
+    "content": [{ 
+      "type": "paragraph",
+      "children": [
+        {
+        "text": "Link to "
+        },
+        {
+        "id": "a6e871fa-bf95-4bc2-81fc-9a1f65da036f",
+        "type": "note-link",
+        "noteId": "94975cb2-0a63-4acd-a6cc-3c849d88f51c",
+        "children": [
+            {
+            "text": "112"
+            }
+        ],
+        "noteTitle": "112"
+        },
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "7d0148ad-6e29-4118-8231-32195b471917",
+    "title": "111=>112",
+    "content": [{
+      "type": "paragraph",
+      "children": [
+        {
+        "text": "Link to "
+        },
+        {
+        "id": "a6e871fa-bf95-4bc2-81fc-9a1f65da036f",
+        "type": "note-link",
+        "noteId": "44936756-b0ad-4c6e-a792-4bb4597c1c1d",
+        "children": [
+            {
+            "text": "112=>111"
+            }
+        ],
+        "noteTitle": "112=>111"
+        },
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "97bd9dea-3b65-45d7-be48-50d3f0f1324a",
+    "title": "002=>221",
+    "content": [{
+      "type": "paragraph",
+      "children": [
+        {
+        "text": "Link to "
+        },
+        {
+        "id": "ee6bbfaf-602b-4ca4-ad40-6bf17a2e49e0",
+        "type": "note-link",
+        "noteId": "471f463c-6b3a-47a6-8c35-08d951790aa6",
+        "children": [
+            {
+            "text": "221"
+            }
+        ],
+        "noteTitle": "221"
+        },
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "5de87bfd-3efb-4daf-b8ae-be362bc54c36",
+    "title": "001=>221",
+    "content": [{ 
+      "type": "paragraph",
+      "children": [
+        {
+        "text": "Link to "
+        },
+        {
+        "id": "0eddf41b-08d3-4ce8-b1ab-a8b90f7a6bb9",
+        "type": "note-link",
+        "noteId": "471f463c-6b3a-47a6-8c35-08d951790aa6",
+        "children": [
+            {
+            "text": "221"
+            }
+        ],
+        "noteTitle": "221"
+        },
+        {
+        "text": ". "
+        }
+      ]
+    }]
+  },
+  {
+    "id": "ca2b54eb-289a-47bc-bcb1-930900bae0c1",
+    "title": "001=>421",
+    "content": [{
+      "type": "paragraph",
+      "children": [
+        {
+        "text": "First link to "
+        },
+        {
+        "id": "5f664989-7eb3-43f5-b87d-42e52b7c9c9f",
+        "type": "note-link",
+        "noteId": "a0950eb3-8e8d-440a-8c6c-6f27256038bf",
+        "children": [
+            {
+            "text": "421"
+            }
+        ],
+        "noteTitle": "421"
+        },
+        {
+        "text": ". Second link to "
+        },
+        {
+        "id": "2a6ed4b6-ca97-4807-bc17-af2775fe4d13",
+        "type": "note-link",
+        "noteId": "a0950eb3-8e8d-440a-8c6c-6f27256038bf",
+        "children": [
+            {
+            "text": "421"
+            }
+        ],
+        "noteTitle": "421"
+        },
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "f2c38b3e-88ff-4c9b-8f2b-abf053034fb7",
+    "title": "002=>421",
+    "content": [{
+      "type": "paragraph",
+      "children": [
+        {
+        "text": "First link to "
+        },
+        {
+        "id": "5f664989-7eb3-43f5-b87d-42e52b7c9c9f",
+        "type": "note-link",
+        "noteId": "a0950eb3-8e8d-440a-8c6c-6f27256038bf",
+        "children": [
+            {
+            "text": "421"
+            }
+        ],
+        "noteTitle": "421"
+        },
+        {
+        "text": ". Second link to "
+        },
+        {
+        "id": "2a6ed4b6-ca97-4807-bc17-af2775fe4d13",
+        "type": "note-link",
+        "noteId": "a0950eb3-8e8d-440a-8c6c-6f27256038bf",
+        "children": [
+            {
+            "text": "421"
+            }
+        ],
+        "noteTitle": "421"
+        },
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "94975cb2-0a63-4acd-a6cc-3c849d88f51c",
+    "title": "112",
+    "content": [{ 
+      "type": "paragraph",
+      "children": [
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "471f463c-6b3a-47a6-8c35-08d951790aa6",
+    "title": "221",
+    "content": [{ 
+      "type": "paragraph",
+      "children": [
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "7f301e32-3d96-4cd4-b502-58de01018370",
+    "title": "111",
+    "content": [{ 
+      "type": "paragraph",
+      "children": [
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "a0950eb3-8e8d-440a-8c6c-6f27256038bf",
+    "title": "421",
+    "content": [{ 
+      "type": "paragraph",
+      "children": [
+        {
+        "text": ""
+        }
+      ]
+    }]
+  },
+  {
+    "id": "c8207f92-b927-4ba5-b1bb-8828723999f3",
+    "title": "211",
+    "content": [{ 
+      "type": "paragraph",
+      "children": [
+        {
+        "text": ""
+        }
+      ]
+    }]
+  }
+]

--- a/cypress/fixtures/notes.json
+++ b/cypress/fixtures/notes.json
@@ -1,6 +1,7 @@
 [
   {
     "id": "bea6ab7b-b4bd-4239-ba38-f170562ff7a9",
+    "user_id": "",
     "title": "001=>111",
     "content": [{
       "type": "paragraph",

--- a/cypress/integration/auth.spec.ts
+++ b/cypress/integration/auth.spec.ts
@@ -51,7 +51,7 @@ describe('User sign up, login, and logout', () => {
 
     cy.get('button[type="submit"]').click();
 
-    cy.selectToastByContent('Invalid');
+    cy.getToastByContent('Invalid');
   });
 
   it('displays toastify login validation error for incorrect username', () => {
@@ -62,7 +62,7 @@ describe('User sign up, login, and logout', () => {
 
     cy.get('button[type="submit"]').click();
 
-    cy.selectToastByContent('Invalid');
+    cy.getToastByContent('Invalid');
   });
 
   it('can sign up using UI', () => {
@@ -91,7 +91,7 @@ describe('User sign up, login, and logout', () => {
     cy.get('input[type="password"]').type(user_new.password);
     cy.get('button[type="submit"').click();
 
-    cy.selectToastByContent('Email not confirmed');
+    cy.getToastByContent('Email not confirmed');
   });
 
   it('displays error if you try to sign up twice within 1 minute', () => {
@@ -109,7 +109,7 @@ describe('User sign up, login, and logout', () => {
     cy.get('button[type="submit"').click();
 
     // error should appear on second sign up
-    cy.selectToastByContent('For security purposes');
+    cy.getToastByContent('For security purposes');
   });
 
   it('displays error if password is less than 6 characters', () => {
@@ -120,7 +120,7 @@ describe('User sign up, login, and logout', () => {
 
     cy.get('button[type="submit"').click();
 
-    cy.selectToastByContent('Password should be at least 6 characters');
+    cy.getToastByContent('Password should be at least 6 characters');
   });
 
   it('displays built-in browser signup validation errors', () => {

--- a/cypress/integration/linkedReferences.spec.ts
+++ b/cypress/integration/linkedReferences.spec.ts
@@ -1,0 +1,233 @@
+import { createClient } from '@supabase/supabase-js';
+import user from '../fixtures/user.json';
+import notes from '../fixtures/notes.json';
+
+const supabase = createClient(
+  Cypress.env('NEXT_PUBLIC_SUPABASE_URL'),
+  Cypress.env('NEXT_PUBLIC_SUPABASE_KEY')
+);
+
+// These tests use the notes from the the 'notes.json fixture
+// The note titles can be read as:
+// {# of references}{# of notes referrencing it}{id}
+// Example: Note '001' has 0 references from 0 notes
+// and is the first of its kind
+// Example: Note '002' has 0 references from 0 notes
+// and it is the second of its kind
+// Example: Note '421' has 4 references from 2 notes
+// and is the first of its kind
+
+// Links to other notes are indicated by '=>'
+// Example: Note '001=>111' means this note has a
+// note link element for note '111'. The result is
+// note '111 'has a linked reference from '001=>111'
+
+describe('linked references', () => {
+  beforeEach(() => {
+    cy.exec('npm run db:seed')
+      .then(() =>
+        supabase.auth.signIn({
+          email: user.email,
+          password: user.password,
+        })
+      )
+      .then(async (result) => {
+        const data = [];
+
+        // insert returned user_id into '../fixtures/notes.json'
+        for (const note of notes) {
+          ((<any>note).user_id = result.user?.id), data.push(note);
+        }
+
+        // insert completed notes to supabase
+        await supabase.from('notes').insert(data);
+      });
+    cy.visit('/app');
+  });
+
+  it('should open an existing note after clicking on a note link element', () => {
+    // open note '001=>111'
+    cy.getSidebarNoteLink('001=>111').click();
+
+    // target page '001=>111' so we can target elements inside
+    cy.targetPage('001=>111').within(() => {
+      // click on the link to note '111'
+      cy.getNoteLinkElement('111').click();
+    });
+
+    // checks if note '111' displayed
+    // if targetPage('111') succeeds, note '111' is visible
+    cy.targetPage('111');
+  });
+
+  it('should show linked references from referring links', () => {
+    // open note '111'
+    cy.getSidebarNoteLink('111').click();
+
+    // target page '001=>111' so we can target elements inside
+    cy.targetPage('111').within(() => {
+      // check note '111' has 1 linked reference
+      cy.numberOfReferencesShouldEqual(1, 'linked');
+      // check the linked reference is from '001=>111'
+      cy.getReference('001=>111', 'linked');
+    });
+  });
+
+  it('should change the note link element text when the source note title is changed', () => {
+    // open note '001=>112'
+    cy.getSidebarNoteLink('001=>112').click();
+
+    // target page '001=>112' so we can target elements inside
+    cy.targetPage('001=>112').within(() => {
+      // click on the link to note '112'
+      cy.getNoteLinkElement('112').click();
+    });
+
+    // intercept the next request trying to update the note
+    cy.intercept('PATCH', '/rest/v1/notes?id=*').as('updateNote');
+
+    // target page '112' so we can target elements inside
+    cy.targetPage('112').within(() => {
+      // change the title from '112' to '112x'
+      cy.getNoteTitle('112').type('x');
+    });
+
+    // wait for the note to finish updating so the link can be found
+    cy.wait('@updateNote').its('response.statusCode').should('eq', 200);
+
+    // reference existing '001=>112' page to target the element inside
+    cy.targetPage('001=>112').within(() => {
+      // the link in note '001=>112' should have changed from '112' to '112x'
+      cy.getNoteLinkElement('112x');
+    });
+  });
+
+  it('should display link references in both notes that are bidirectionally linked', () => {
+    // open note '111=>112'
+    cy.getSidebarNoteLink('111=>112').click();
+
+    // target page '111=>112' so we can target elements inside
+    cy.targetPage('111=>112').within(() => {
+      // check note '111=>112' has 1 linked reference
+      cy.numberOfReferencesShouldEqual(1, 'linked');
+      // check note '111=>112' is referenced by '112=>111'
+      cy.getReference('112=>111', 'linked');
+      // click on the link to '112=>111'
+      cy.getNoteLinkElement('112=>111').click();
+    });
+
+    // target page '112=>111' so we can target elements inside
+    cy.targetPage('112=>111').within(() => {
+      // check note '112=>111' has 1 linked reference
+      cy.numberOfReferencesShouldEqual(1, 'linked');
+      // check note '112=>111' is referenced by '111=>112'
+      cy.getReference('111=>112', 'linked');
+      // check link to note '111=>112' exists
+      cy.getNoteLinkElement('111=>112');
+    });
+  });
+
+  it('should display multiple references from the same file in the same backlink note branch', () => {
+    // open note '001=>211'
+    cy.getSidebarNoteLink('001=>211').click();
+
+    // target page '001=>211' so we can target elements inside
+    cy.targetPage('001=>211').within(() => {
+      // create a new note link element referencing note 211
+      cy.getEditor().type('[[211]]');
+      // click on the link to note '211'
+      // first() is specified because there are multiple links to note 211
+      cy.getNoteLinkElement('211').first().click();
+    });
+
+    // target page '211' so we can target elements inside
+    cy.targetPage('211').within(() => {
+      // check there is only 1 note referencing this note
+      cy.numberOfReferencesShouldEqual(1, 'linked');
+      // check note '211' is referenced by '001=>211'
+      cy.getReference('001=>211', 'linked');
+      // check there are 3 links within that note
+      cy.getNoteLinkElement('211').should('have.length', 3);
+    });
+  });
+
+  it('should display references from different pages in their own backlink note branch', () => {
+    // open note '221'
+    cy.getSidebarNoteLink('221').click();
+
+    // target page '211' so we can target elements inside
+    cy.targetPage('221').within(() => {
+      // note should be referenced by two notes
+      cy.numberOfReferencesShouldEqual(2, 'linked');
+      // there should be 1 reference from note '001=>221'
+      cy.getReference('001=>221', 'linked').should('have.length', 1);
+      // there should be 1 reference from note '002=>221'
+      cy.getReference('002=>221', 'linked').should('have.length', 1);
+    });
+  });
+
+  it('should open note when you click on backlink note branch', () => {
+    // open note '111'
+    cy.getSidebarNoteLink('111').click();
+
+    // target page '111' so we can target elements inside
+    cy.targetPage('111').within(() => {
+      // click on note '001=>111' in the linked reference section
+      cy.getReference('001=>111', 'linked').click();
+    });
+
+    // check if note '001=>111' is displayed
+    cy.targetPage('001=>111');
+  });
+
+  it('should remove note link elements when notes are deleted', () => {
+    // open note '111'
+    cy.getSidebarNoteLink('111').click();
+
+    // intercept the next request trying to update the note
+    cy.intercept('DELETE', '/rest/v1/notes?id=*').as('deleted');
+
+    // click on the [...] button on the note page
+    cy.get('[data-testid="note-menu-button"]').click();
+    // click on the delete dropdown-menu-item
+    cy.get('[data-testid="note-menu-button-dropdown"] button')
+      .contains('Delete')
+      .click();
+
+    // wait for the note to be deleted
+    cy.wait('@deleted').its('response.statusCode').should('eq', 200);
+
+    // open note '001=>111'
+    cy.getSidebarNoteLink('001=>111').click();
+
+    // target page '001=>111' so we can target elements inside
+    cy.targetPage('001=>111').within(() => {
+      // check that the text '111' exists
+      cy.getEditor().contains('111');
+      // but the '111' text is no longer a note link element
+      cy.getNoteLinkElement('111').should('not.exist');
+    });
+  });
+
+  it('should remove linked reference when the reference is deleted', () => {
+    // open note '001=>111'
+    cy.getSidebarNoteLink('001=>111').click();
+
+    // target page '001=>111' so we can target elements inside
+    cy.targetPage('001=>111').within(() => {
+      // delete the note link element for '111' using the keyboard
+      cy.getEditor().type('{moveToEnd}{backspace}');
+      // check '111' note link element was deleted
+      cy.getNoteLinkElement('111').should('not.exist');
+    });
+
+    // open note '111'
+    cy.getSidebarNoteLink('111').click();
+
+    // target page '111' so we can target elements inside=
+    cy.targetPage('111').within(() => {
+      // note '001=>111' should no longer reference this note
+      cy.numberOfReferencesShouldEqual(0, 'linked');
+    });
+  });
+});

--- a/cypress/integration/linkedReferences.spec.ts
+++ b/cypress/integration/linkedReferences.spec.ts
@@ -67,7 +67,7 @@ describe('linked references', () => {
     // target page '001=>111' so we can target elements inside
     cy.targetPage('111').within(() => {
       // check note '111' has 1 linked reference
-      cy.getNumberOfLinkedReferencesTo('111').should('have.length', 1);
+      cy.getNumberOfLinkedReferences().should('have.length', 1);
       // check the linked reference is from '001=>111'
       cy.getLinkedReference('001=>111');
     });
@@ -103,7 +103,7 @@ describe('linked references', () => {
     // target page '111=>112' so we can target elements inside
     cy.targetPage('111=>112').within(() => {
       // check note '111=>112' has 1 linked reference
-      cy.getNumberOfLinkedReferencesTo('111=>112').should('have.length', 1);
+      cy.getNumberOfLinkedReferences().should('have.length', 1);
       // check note '111=>112' is referenced by '112=>111'
       cy.getLinkedReference('112=>111');
       // click on the link to '112=>111'
@@ -113,7 +113,7 @@ describe('linked references', () => {
     // target page '112=>111' so we can target elements inside
     cy.targetPage('112=>111').within(() => {
       // check note '112=>111' has 1 linked reference
-      cy.getNumberOfLinkedReferencesTo('112=>111').should('have.length', 1);
+      cy.getNumberOfLinkedReferences().should('have.length', 1);
       // check note '112=>111' is referenced by '111=>112'
       cy.getLinkedReference('111=>112');
       // check link to note '111=>112' exists
@@ -141,7 +141,7 @@ describe('linked references', () => {
       // check note '211' is referenced by '001=>211'
       cy.getLinkedReference('001=>211');
       // check there are 3 linked references to that note
-      cy.getNumberOfLinkedReferencesTo('211').should('have.length', 3);
+      cy.getNumberOfLinkedReferences().should('have.length', 3);
     });
   });
 
@@ -170,7 +170,7 @@ describe('linked references', () => {
       cy.get('p').contains('Linked References').and('contain', '4');
 
       // there should be 4 link references to note '421'
-      cy.getNumberOfLinkedReferencesTo('421').should('have.length', 4);
+      cy.getNumberOfLinkedReferences().should('have.length', 4);
     });
   });
 
@@ -235,7 +235,7 @@ describe('linked references', () => {
     // target page '111' so we can target elements inside=
     cy.targetPage('111').within(() => {
       // note '001=>111' should no longer reference this note
-      cy.getNumberOfLinkedReferencesTo('111').should('have.length', 0);
+      cy.getNumberOfLinkedReferences().should('have.length', 0);
     });
   });
 });

--- a/cypress/integration/pages.spec.ts
+++ b/cypress/integration/pages.spec.ts
@@ -36,12 +36,12 @@ describe('pages', () => {
     // first() is specified because there are multiple links to note 211
     cy.getNoteLinkElement('421').first().click();
 
-    // reference existing '001=>421' page alias to target the element inside
+    // target page '001=>421' so we can target elements inside
     cy.targetPage('001=>421').within(() => {
       cy.getEditor().type('l');
     });
 
-    // reference existing '421' page alias to target the element inside
+    // target page '421' so we can target elements inside
     cy.targetPage('421').within(() => {
       cy.getEditor().type('r');
     });

--- a/cypress/integration/pages.spec.ts
+++ b/cypress/integration/pages.spec.ts
@@ -21,7 +21,7 @@ describe('pages', () => {
 
         // insert returned user_id into '../fixtures/notes.json'
         for (const note of notes) {
-          ((<any>note).user_id = result.user?.id), data.push(note);
+          (note.user_id = result.user?.id), data.push(note);
         }
         await supabase.from('notes').insert(data);
       });

--- a/cypress/integration/pages.spec.ts
+++ b/cypress/integration/pages.spec.ts
@@ -1,0 +1,49 @@
+import { createClient } from '@supabase/supabase-js';
+import user from '../fixtures/user.json';
+import notes from '../fixtures/notes.json';
+
+const supabase = createClient(
+  Cypress.env('NEXT_PUBLIC_SUPABASE_URL'),
+  Cypress.env('NEXT_PUBLIC_SUPABASE_KEY')
+);
+
+describe('pages', () => {
+  beforeEach(() => {
+    cy.exec('npm run db:seed')
+      .then(() =>
+        supabase.auth.signIn({
+          email: user.email,
+          password: user.password,
+        })
+      )
+      .then(async (result) => {
+        const data = [];
+
+        // insert returned user_id into '../fixtures/notes.json'
+        for (const note of notes) {
+          ((<any>note).user_id = result.user?.id), data.push(note);
+        }
+        await supabase.from('notes').insert(data);
+      });
+    cy.visit('/app');
+  });
+
+  it('should be able to target elements on different pages', () => {
+    // open note '001=>421'
+    cy.getSidebarNoteLink('001=>421').click();
+
+    // click on the link to note '211'
+    // first() is specified because there are multiple links to note 211
+    cy.getNoteLinkElement('421').first().click();
+
+    // reference existing '001=>421' page alias to target the element inside
+    cy.targetPage('001=>421').within(() => {
+      cy.getEditor().type('l');
+    });
+
+    // reference existing '421' page alias to target the element inside
+    cy.targetPage('421').within(() => {
+      cy.getEditor().type('r');
+    });
+  });
+});

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -14,11 +14,9 @@ declare namespace Cypress {
 
     /**
      * Get the number of linked references to a page
-     * @example cy.getNumberOfLinkedReferencesTo('pageTitle')
+     * @example cy.getNumberOfLinkedReferences('pageTitle')
      */
-    getNumberOfLinkedReferencesTo(
-      pageTitle: string
-    ): Chainable<JQuery<HTMLElement>>;
+    getNumberOfLinkedReferences(): Chainable<JQuery<HTMLElement>>;
 
     /**
      * Get linked reference based on its note title

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -7,19 +7,24 @@ declare namespace Cypress {
     targetPage(noteTitle: string): Chainable<JQuery<HTMLElement>>;
 
     /**
-     * Assert there is a certain amount of backlinks
-     * @example cy.numberOfReferencesShouldEqual('linked', 5)
+     * Gets elements for each note in the linked references section
+     * @example cy.getNumberOfNotesWithLinkedReferences()
      */
-    numberOfReferencesShouldEqual(amount: number, referenceType: string);
+    getNumberOfNotesWithLinkedReferences(): Chainable<JQuery<HTMLElement>>;
 
     /**
-     * Get linked or unlinked reference based its note title
-     * @example cy.getReference('linked', 'title')
+     * Get the number of linked references to a page
+     * @example cy.getNumberOfLinkedReferencesTo('pageTitle')
      */
-    getReference(
-      noteTitle: string,
-      referenceType: string
+    getNumberOfLinkedReferencesTo(
+      pageTitle: string
     ): Chainable<JQuery<HTMLElement>>;
+
+    /**
+     * Get linked reference based on its note title
+     * @example cy.getLinkedReference('title')
+     */
+    getLinkedReference(noteTitle: string): Chainable<JQuery<HTMLElement>>;
 
     /**
      * Get note link element in the editor

--- a/cypress/support/commands.d.ts
+++ b/cypress/support/commands.d.ts
@@ -1,20 +1,62 @@
 declare namespace Cypress {
   interface Chainable {
     /**
-     * Selects a Toastify element by its content
-     * @example cy.selectToastByContent('content')
+     * Target a page to test elements within it
+     * @example cy.targetPage('title')
      */
-    selectToastByContent(content: string);
+    targetPage(noteTitle: string): Chainable<JQuery<HTMLElement>>;
+
+    /**
+     * Assert there is a certain amount of backlinks
+     * @example cy.numberOfReferencesShouldEqual('linked', 5)
+     */
+    numberOfReferencesShouldEqual(amount: number, referenceType: string);
+
+    /**
+     * Get linked or unlinked reference based its note title
+     * @example cy.getReference('linked', 'title')
+     */
+    getReference(
+      noteTitle: string,
+      referenceType: string
+    ): Chainable<JQuery<HTMLElement>>;
+
+    /**
+     * Get note link element in the editor
+     * @example cy.clickNoteLinkElement('title')
+     */
+    getNoteLinkElement(noteTitle: string): Chainable<JQuery<HTMLElement>>;
+
+    /**
+     * Get the editable title of a note on its note page
+     * @example cy.getNoteTitle('title')
+     */
+    getNoteTitle(noteTitle: string): Chainable<JQuery<HTMLElement>>;
+
+    /**
+     * Gets a note in the sidebar by its title
+     * @example cy.getSidebarNoteLink('title')
+     */
+    getSidebarNoteLink(noteTitle: string): Chainable<JQuery<HTMLElement>>;
+
+    /**
+     * * Selects a Toastify element by its content
+     * @example cy.getToastByContent('content')
+     */
+    getToastByContent(content: string): Chainable<JQuery<HTMLElement>>;
+
     /**
      * Gets the Slate editor element.
      * @example cy.getEditor()
      */
     getEditor(): Chainable<JQuery<HTMLElement>>;
+
     /**
      * Custom command to paste text.
      * @example cy.paste('value')
      */
     paste(value: string, type?: string): Chainable<Element>;
+
     /**
      * Sets the selection.
      * @param query Beginning text

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -48,10 +48,62 @@ Cypress.Commands.add(
   }
 );
 
-Cypress.Commands.add('getEditor', () => cy.get('[data-slate-editor=true]'));
+Cypress.Commands.add('getEditor', () => cy.get('[data-testid="note-editor"]'));
 
 // This is not a great way to target elements, but
-// toastify doesn't support adding data attributes
-Cypress.Commands.add('selectToastByContent', (content) =>
+// Toastify doesn't support adding data attributes
+Cypress.Commands.add('getToastByContent', (content) =>
   cy.get('.Toastify__toast-body').should('be.visible').contains(content)
 );
+
+Cypress.Commands.add('getSidebarNoteLink', (noteTitle) => {
+  cy.get(`[data-testid="sidebar-note-link-${noteTitle}"]`);
+});
+
+Cypress.Commands.add('getNoteLinkElement', (noteTitle) => {
+  cy.get(`[data-testid="note-link-element-${noteTitle}"]`);
+});
+
+// Gets the element where the note's title is editable
+// contains() by default allows for partial matches
+// But this RegExp finds the exact match of noteTitle
+// '^' asserts position at start of the string
+// '$' asserts position at end of string
+Cypress.Commands.add('getNoteTitle', (noteTitle) => {
+  cy.get('[data-testid="note-title"]').contains(
+    new RegExp('^' + noteTitle + '$')
+  );
+});
+
+// Gets a linked or unlinked reference by the note's title
+// You must pass "linked" or "unlinked" for referenceType
+// Linked references have the testid of "linked-reference"
+// Unlinked references have the testid of "unlinked-reference"
+Cypress.Commands.add('getReference', (noteTitle, referenceType) => {
+  cy.get(`[data-testid="${referenceType}-reference"]`).contains(
+    new RegExp('^' + noteTitle + '$')
+  );
+});
+
+// Asserts the amount of references of a specific type a note should have
+// You must pass "linked" or "unlinked" for referenceType
+Cypress.Commands.add(
+  'numberOfReferencesShouldEqual',
+  (number, referenceType) => {
+    cy.get(`[data-testid="${referenceType}-reference"]`).should(
+      'have.length',
+      number
+    );
+  }
+);
+
+// Uses within() to target elements within that page
+// see: https://docs.cypress.io/api/commands/within
+
+// Example:
+//    cy.targetPage('noteTitle').within(() => {
+//      // write test code here
+//    })
+Cypress.Commands.add('targetPage', (noteTitle) => {
+  cy.getNoteTitle(noteTitle).parent();
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -90,7 +90,7 @@ Cypress.Commands.add('getNumberOfNotesWithLinkedReferences', () => {
 });
 
 // Gets the number of linked references to a page
-Cypress.Commands.add('getNumberOfLinkedReferencesTo', (pageTitle) => {
+Cypress.Commands.add('getNumberOfLinkedReferences', () => {
   cy.get('[contenteditable="false"] [data-testid="note-link-element"]');
 });
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -57,11 +57,13 @@ Cypress.Commands.add('getToastByContent', (content) =>
 );
 
 Cypress.Commands.add('getSidebarNoteLink', (noteTitle) => {
-  cy.get(`[data-testid="sidebar-note-link-${noteTitle}"]`);
+  cy.get('[data-testid="sidebar-note-link"]').contains(
+    new RegExp('^' + noteTitle + '$')
+  );
 });
 
 Cypress.Commands.add('getNoteLinkElement', (noteTitle) => {
-  cy.get(`[data-testid="note-link-element-${noteTitle}"]`);
+  cy.get('[data-testid="note-link-element"]').should('contain', noteTitle);
 });
 
 // Gets the element where the note's title is editable
@@ -75,27 +77,22 @@ Cypress.Commands.add('getNoteTitle', (noteTitle) => {
   );
 });
 
-// Gets a linked or unlinked reference by the note's title
-// You must pass "linked" or "unlinked" for referenceType
-// Linked references have the testid of "linked-reference"
-// Unlinked references have the testid of "unlinked-reference"
-Cypress.Commands.add('getReference', (noteTitle, referenceType) => {
-  cy.get(`[data-testid="${referenceType}-reference"]`).contains(
+// Gets a linked reference by the note's title
+Cypress.Commands.add('getLinkedReference', (noteTitle) => {
+  cy.get(`[data-testid="linked-reference"]`).contains(
     new RegExp('^' + noteTitle + '$')
   );
 });
 
-// Asserts the amount of references of a specific type a note should have
-// You must pass "linked" or "unlinked" for referenceType
-Cypress.Commands.add(
-  'numberOfReferencesShouldEqual',
-  (number, referenceType) => {
-    cy.get(`[data-testid="${referenceType}-reference"]`).should(
-      'have.length',
-      number
-    );
-  }
-);
+// Gets elements for each note in the linked references section
+Cypress.Commands.add('getNumberOfNotesWithLinkedReferences', () => {
+  cy.get('[data-testid="linked-reference"]');
+});
+
+// Gets the number of linked references to a page
+Cypress.Commands.add('getNumberOfLinkedReferencesTo', (pageTitle) => {
+  cy.get('[contenteditable="false"] [data-testid="note-link-element"]');
+});
 
 // Uses within() to target elements within that page
 // see: https://docs.cypress.io/api/commands/within


### PR DESCRIPTION
These tests focus on note link elements and linked references. They also lay the groundwork for future tests.

Since Notabase can have multiple pages open at the same time, there has to be some way to isolate pages so elements can be reliably targeted. For example, the old `getEditor` `Cypress.Command` used `[data-slate-editor=true]` to target the editor. This works with one page, but if two or more pages were open, or a linked reference existed, then `getEditor` would find more than one `[data-slate-editor=true]` and Cypress would throw an error.

The approach I took is to target individual pages before trying to locate elements within them.

```
cy.targetPage('noteTitle').within(() => {
  // code inside will be isolated to this page
})
```

By isolating each page it removes interference between pages which will make the tests more stable and easy to maintain.

Some things to mention:

I added some data attributes and some of them will be long. For example, I use `data-testid={"note-link-element-" + element.noteTitle}` which would be long if a note’s title is long.

I added a prop to BacklinkNoteBranch so I could create a conditional data attribute: `data-testid={isLinked ? "linked-reference" : "unlinked-reference"}`. But I’m no React expert so it would be nice if you could take a look at that.

There is also an auth issue I have when running all the tests at once, and I’m curious if that is a limitation due to how I hooked up to Supabase or whether you also get the same issue.
