### PR TITLE
Only show arrows next to notes if there are children

### DIFF
--- a/components/sidebar/Sidebar.tsx
+++ b/components/sidebar/Sidebar.tsx
@@ -128,14 +128,14 @@ const FindOrCreateModalButton = (props: FindOrCreateModalButtonProps) => {
         touch={false}
       >
         <button
-          className="flex w-full items-center px-6 py-1 text-left"
+          className="flex h-8 w-full items-center px-6 py-1 text-left"
           onClick={onClick}
         >
           <IconSearch
             className="mr-1 flex-shrink-0 text-gray-800 dark:text-gray-300"
-            size={20}
+            size={16}
           />
-          <span className="select-none overflow-x-hidden overflow-ellipsis whitespace-nowrap">
+          <span className="select-none overflow-x-hidden overflow-ellipsis whitespace-nowrap text-sm">
             Find or Create Note
           </span>
         </button>
@@ -163,12 +163,12 @@ const GraphButton = (props: GraphButtonProps) => {
         touch={false}
       >
         <span>
-          <Link href="/app/graph" className="flex items-center px-6 py-1">
+          <Link href="/app/graph" className="flex h-8 items-center px-6 py-1">
             <IconAffiliate
               className="mr-1 flex-shrink-0 text-gray-800 dark:text-gray-300"
-              size={20}
+              size={16}
             />
-            <span className="select-none overflow-x-hidden overflow-ellipsis whitespace-nowrap">
+            <span className="select-none overflow-x-hidden overflow-ellipsis whitespace-nowrap text-sm">
               Graph View
             </span>
           </Link>

--- a/components/sidebar/SidebarNoteLink.tsx
+++ b/components/sidebar/SidebarNoteLink.tsx
@@ -6,7 +6,7 @@ import {
   useCallback,
   useMemo,
 } from 'react';
-import { IconCaretRight } from '@tabler/icons';
+import { IconCaretRight, IconFile } from '@tabler/icons';
 import { useStore } from 'lib/store';
 import { isMobile } from 'utils/device';
 import useOnNoteLinkClick from 'editor/useOnNoteLinkClick';
@@ -41,8 +41,8 @@ const SidebarNoteLink = (
     [node, toggleNoteTreeItemCollapsed]
   );
 
-  // We add 16px for every level of nesting, plus 8px base padding
-  const leftPadding = useMemo(() => node.depth * 16 + 8, [node.depth]);
+  // We add 20px for every level of nesting, plus 4px base padding
+  const leftPadding = useMemo(() => node.depth * 20 + 4, [node.depth]);
 
   return (
     <SidebarItem
@@ -65,25 +65,34 @@ const SidebarNoteLink = (
         style={{ paddingLeft: `${leftPadding}px` }}
         draggable={false}
       >
-        <button
-          className="mr-1 rounded p-1 hover:bg-gray-300 active:bg-gray-400 dark:hover:bg-gray-600 dark:active:bg-gray-500"
-          onClick={(e) => {
-            e.preventDefault();
-            e.stopPropagation();
-            onArrowClick?.();
-          }}
-        >
-          <IconCaretRight
-            className={`flex-shrink-0 transform text-gray-500 transition-transform dark:text-gray-100 ${
-              !node.collapsed ? 'rotate-90' : ''
-            }`}
-            size={16}
-            fill="currentColor"
-          />
-        </button>
+        {node.hasChildren ? (
+          <button
+            className="rounded p-1 hover:bg-gray-300 active:bg-gray-400 dark:hover:bg-gray-600 dark:active:bg-gray-500"
+            onClick={(e) => {
+              e.preventDefault();
+              e.stopPropagation();
+              onArrowClick?.();
+            }}
+          >
+            <IconCaretRight
+              className={`flex-shrink-0 transform text-gray-500 transition-transform dark:text-gray-100 ${
+                !node.collapsed ? 'rotate-90' : ''
+              }`}
+              size={16}
+              fill="currentColor"
+            />
+          </button>
+        ) : null}
+        <IconFile
+          className={`mr-1 flex-shrink-0 text-gray-500 dark:text-gray-100 ${
+            !node.hasChildren ? 'ml-6' : ''
+          }`}
+          size={16}
+        />
         <span
-          className="overflow-hidden overflow-ellipsis whitespace-nowrap"
+          className="overflow-hidden overflow-ellipsis whitespace-nowrap text-sm"
           data-testid="sidebar-note-link"
+          title={note.title}
         >
           {note.title}
         </span>

--- a/components/sidebar/SidebarNoteLinkDropdown.tsx
+++ b/components/sidebar/SidebarNoteLinkDropdown.tsx
@@ -41,8 +41,11 @@ const SidebarNoteLinkDropdown = (props: Props) => {
               ref={containerRef}
               className={`rounded hover:bg-gray-300 active:bg-gray-400 dark:hover:bg-gray-600 dark:active:bg-gray-500 ${className}`}
             >
-              <span className="flex h-8 w-8 items-center justify-center">
-                <IconDots className="text-gray-600 dark:text-gray-200" />
+              <span className="flex items-center justify-center p-1">
+                <IconDots
+                  className="text-gray-600 dark:text-gray-200"
+                  size={16}
+                />
               </span>
             </Menu.Button>
             {open && (

--- a/components/sidebar/SidebarNotesTree.tsx
+++ b/components/sidebar/SidebarNotesTree.tsx
@@ -37,6 +37,7 @@ export type FlattenedNoteTreeItem = {
   id: string;
   depth: number;
   collapsed: boolean;
+  hasChildren: boolean;
 };
 
 type Props = {
@@ -74,7 +75,7 @@ function SidebarNotesTree(props: Props) {
   const flattenNode = useCallback(
     (node: NoteTreeItem, depth: number, result: FlattenedNoteTreeItem[]) => {
       const { id, children, collapsed } = node;
-      result.push({ id, depth, collapsed });
+      result.push({ id, depth, collapsed, hasChildren: children.length > 0 });
 
       /**
        * Only push in children if:
@@ -177,6 +178,7 @@ function SidebarNotesTree(props: Props) {
                     id: activeId,
                     depth: 0,
                     collapsed: false,
+                    hasChildren: false,
                   }
                 }
                 className="!bg-gray-50 shadow-popover dark:!bg-gray-800"


### PR DESCRIPTION
- Only show arrows next to notes in the note tree if there are children
- Reduce text size of note titles to show more of the title
- Add icon next to notes

Fixes https://github.com/churichard/notabase/issues/1179