### PR TITLE
Reduce note content egress with lazy loading

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -20,7 +20,11 @@ jobs:
       - uses: supabase/setup-cli@v1.1.4
         with:
           version: latest
-      - run: supabase start
+      - name: Start Supabase from the test schema
+        run: |
+          mv supabase/migrations /tmp/notabase-migrations
+          trap 'mv /tmp/notabase-migrations supabase/migrations' EXIT
+          supabase start
       - run: supabase status -o env --override-name api.url=NEXT_PUBLIC_SUPABASE_URL --override-name auth.anon_key=NEXT_PUBLIC_SUPABASE_KEY --override-name auth.service_role_key=SUPABASE_SERVICE_KEY | tee .env.local .env.test
 
       - name: Cypress run

--- a/__mocks__/supabase.ts
+++ b/__mocks__/supabase.ts
@@ -4,9 +4,11 @@ export default {
   on: jest.fn().mockReturnThis(),
   select: jest.fn().mockReturnThis(),
   eq: jest.fn().mockReturnThis(),
+  in: jest.fn().mockReturnThis(),
   order: jest.fn().mockReturnThis(),
   single: jest.fn().mockReturnThis(),
   maybeSingle: jest.fn().mockReturnThis(),
+  then: jest.fn((resolve) => resolve({ data: null, error: null })),
   subscribe: jest.fn().mockReturnThis(),
   unsubscribe: jest.fn().mockReturnThis(),
 };

--- a/__tests__/components/AppLayout.test.tsx
+++ b/__tests__/components/AppLayout.test.tsx
@@ -43,6 +43,10 @@ describe('AppLayout', () => {
 
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
     expect(supabase.from).toHaveBeenCalledWith('notes');
+    expect(supabaseMock.select).toHaveBeenCalledWith(
+      'id, user_id, title, created_at, updated_at, visibility'
+    );
+    expect(supabaseMock.select).not.toHaveBeenCalledWith('*');
 
     expect(await screen.findByText('Test')).toBeInTheDocument();
   });

--- a/__tests__/lib/noteContent.test.ts
+++ b/__tests__/lib/noteContent.test.ts
@@ -1,0 +1,66 @@
+import type { Descendant } from 'slate';
+import {
+  INLINE_IMAGE_ERROR_MESSAGE,
+  MAX_NOTE_BYTES,
+  NOTE_SIZE_ERROR_MESSAGE,
+  NOTE_WARNING_BYTES,
+  getNoteContentBytes,
+  hasInlineImageData,
+  validateNoteContent,
+} from 'lib/noteContent';
+
+const contentWithByteSize = (target: number): Descendant[] => {
+  const content = [
+    { type: 'paragraph', children: [{ text: '' }] },
+  ] as Descendant[];
+  const overhead = getNoteContentBytes(content);
+  (content[0] as { children: { text: string }[] }).children[0].text =
+    'a'.repeat(target - overhead);
+  return content;
+};
+
+describe('note content limits', () => {
+  it('measures UTF-8 bytes rather than JavaScript string length', () => {
+    const content = [
+      { type: 'paragraph', children: [{ text: '😀' }] },
+    ] as Descendant[];
+    expect(getNoteContentBytes(content)).toBe(
+      Buffer.byteLength(JSON.stringify(content), 'utf8')
+    );
+    expect(getNoteContentBytes(content)).toBeGreaterThan(
+      JSON.stringify(content).length
+    );
+  });
+
+  it('accepts content at the 5 MB limit', () => {
+    expect(getNoteContentBytes(contentWithByteSize(MAX_NOTE_BYTES))).toBe(
+      MAX_NOTE_BYTES
+    );
+    expect(validateNoteContent(contentWithByteSize(MAX_NOTE_BYTES))).toBeNull();
+  });
+
+  it('rejects content above the 5 MB limit', () => {
+    expect(validateNoteContent(contentWithByteSize(MAX_NOTE_BYTES + 1))).toBe(
+      NOTE_SIZE_ERROR_MESSAGE
+    );
+  });
+
+  it('exposes the warning threshold below the hard limit', () => {
+    expect(NOTE_WARNING_BYTES).toBeLessThan(MAX_NOTE_BYTES);
+    expect(
+      validateNoteContent(contentWithByteSize(NOTE_WARNING_BYTES))
+    ).toBeNull();
+  });
+
+  it('rejects inline image data anywhere in the Slate value', () => {
+    const content = [
+      {
+        type: 'image',
+        url: 'data:image/png;base64,aGVsbG8=',
+        children: [{ text: '' }],
+      },
+    ] as Descendant[];
+    expect(hasInlineImageData(content)).toBe(true);
+    expect(validateNoteContent(content)).toBe(INLINE_IMAGE_ERROR_MESSAGE);
+  });
+});

--- a/components/AppLayout.tsx
+++ b/components/AppLayout.tsx
@@ -14,6 +14,7 @@ import useHotkeys from 'utils/useHotkeys';
 import { PlanId, PRICING_PLANS } from 'constants/pricing';
 import { isMobile } from 'utils/device';
 import { getNoteTreeItem } from 'lib/storeUtils';
+import { refreshBacklinkNote } from 'lib/api/loadBacklinkIndex';
 import Sidebar from './sidebar/Sidebar';
 import FindOrCreateModal from './FindOrCreateModal';
 import PageLoading from './PageLoading';
@@ -59,6 +60,11 @@ export default function AppLayout(props: Props) {
   }, [setupStore]);
 
   const setNotes = useStore((state) => state.setNotes);
+  const setLoadedNoteContent = useStore((state) => state.setLoadedNoteContent);
+  const setBacklinkNotes = useStore((state) => state.setBacklinkNotes);
+  const setIsBacklinkIndexLoaded = useStore(
+    (state) => state.setIsBacklinkIndexLoaded
+  );
   const setNoteTree = useStore((state) => state.setNoteTree);
   const initData = useCallback(async () => {
     if (!user) {
@@ -67,7 +73,7 @@ export default function AppLayout(props: Props) {
 
     const { data: notes } = await supabase
       .from('notes')
-      .select()
+      .select('id, user_id, title, created_at, updated_at, visibility')
       .eq('user_id', user.id)
       .order('title');
 
@@ -94,9 +100,12 @@ export default function AppLayout(props: Props) {
 
     // Set notes
     const notesAsObj = notes.reduce<Record<Note['id'], Note>>((acc, note) => {
-      acc[note.id] = note;
+      acc[note.id] = { ...note, content: [] };
       return acc;
     }, {});
+    setLoadedNoteContent({});
+    setBacklinkNotes({});
+    setIsBacklinkIndexLoaded(false);
     setNotes(notesAsObj);
 
     // Set note tree
@@ -126,7 +135,15 @@ export default function AppLayout(props: Props) {
     }
 
     setIsPageLoaded(true);
-  }, [user, router, setNotes, setNoteTree]);
+  }, [
+    user,
+    router,
+    setNotes,
+    setNoteTree,
+    setLoadedNoteContent,
+    setBacklinkNotes,
+    setIsBacklinkIndexLoaded,
+  ]);
 
   useEffect(() => {
     if (isLoaded && !user) {
@@ -195,25 +212,55 @@ export default function AppLayout(props: Props) {
       .channel(`public:notes:user_id=eq.${user.id}`)
       .on(
         'postgres_changes',
-        { event: 'INSERT', schema: 'public', table: 'notes' },
+        {
+          event: 'INSERT',
+          schema: 'public',
+          table: 'notes',
+          filter: `user_id=eq.${user.id}`,
+        },
         (payload: { new: Note }) => {
-          upsertNote(payload.new);
-        }
-      )
-      .on(
-        'postgres_changes',
-        { event: 'UPDATE', schema: 'public', table: 'notes' },
-        (payload: { new: Note }) => {
-          // Don't update the note if it is currently open
-          const openNoteIds = store.getState().openNoteIds;
-          if (!openNoteIds.includes(payload.new.id)) {
-            updateNote(payload.new);
+          // Notes created by this client are already in the store with their
+          // real content; don't overwrite them with the stripped payload
+          if (!store.getState().notes[payload.new.id]) {
+            upsertNote({ ...payload.new, content: [] });
           }
         }
       )
       .on(
         'postgres_changes',
-        { event: 'DELETE', schema: 'public', table: 'notes' },
+        {
+          event: 'UPDATE',
+          schema: 'public',
+          table: 'notes',
+          filter: `user_id=eq.${user.id}`,
+        },
+        (payload: { new: Note }) => {
+          // Don't update the note if it is currently open
+          const openNoteIds = store.getState().openNoteIds;
+          if (!openNoteIds.includes(payload.new.id)) {
+            updateNote({
+              id: payload.new.id,
+              title: payload.new.title,
+              user_id: payload.new.user_id,
+              created_at: payload.new.created_at,
+              updated_at: payload.new.updated_at,
+              visibility: payload.new.visibility,
+            });
+            // The payload doesn't include content, so any cached content is
+            // now stale; refetch it the next time the note is opened
+            store.getState().setNoteContentLoaded(payload.new.id, false);
+            refreshBacklinkNote(payload.new.id);
+          }
+        }
+      )
+      .on(
+        'postgres_changes',
+        {
+          event: 'DELETE',
+          schema: 'public',
+          table: 'notes',
+          filter: `user_id=eq.${user.id}`,
+        },
         (payload) => {
           deleteNote(payload.old.id);
         }

--- a/components/Note.tsx
+++ b/components/Note.tsx
@@ -11,6 +11,16 @@ import { ProvideCurrentNote } from 'utils/useCurrentNote';
 import { caseInsensitiveStringEqual } from 'utils/string';
 import updateBacklinks from 'editor/backlinks/updateBacklinks';
 import STRINGS from 'constants/strings';
+import loadNoteContent from 'lib/api/loadNoteContent';
+import {
+  INLINE_IMAGE_DB_ERROR,
+  INLINE_IMAGE_ERROR_MESSAGE,
+  NOTE_SIZE_ERROR_CODE,
+  NOTE_SIZE_ERROR_MESSAGE,
+  NOTE_WARNING_BYTES,
+  getNoteContentBytes,
+} from 'lib/noteContent';
+import PageLoading from './PageLoading';
 import Backlinks from './editor/backlinks/Backlinks';
 import NoteHeader from './editor/NoteHeader';
 import ErrorBoundary from './ErrorBoundary';
@@ -31,6 +41,24 @@ function Note(props: Props) {
   const router = useRouter();
 
   const updateNote = useStore((state) => state.updateNote);
+  const isContentLoaded = useStore(
+    (state) => !!state.loadedNoteContent[noteId]
+  );
+  const [contentLoadFailed, setContentLoadFailed] = useState(false);
+
+  useEffect(() => {
+    setContentLoadFailed(false);
+    if (isContentLoaded) {
+      return;
+    }
+    let cancelled = false;
+    loadNoteContent(noteId).then((loaded) => {
+      if (!loaded && !cancelled) setContentLoadFailed(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [isContentLoaded, noteId]);
 
   const [syncState, setSyncState] = useState({
     isTitleSynced: true,
@@ -68,10 +96,27 @@ function Note(props: Props) {
   }, []);
 
   const handleNoteUpdate = useCallback(async (note: NoteUpdate) => {
+    // This runs on the debounced sync rather than on every keystroke since
+    // measuring the content serializes the entire note
+    if (
+      note.content &&
+      getNoteContentBytes(note.content) >= NOTE_WARNING_BYTES
+    ) {
+      toast.warn('This note is close to the 5 MB limit.', {
+        toastId: `note-size-warning-${note.id}`,
+      });
+    }
     const { error } = await updateDbNote(note);
 
     if (error) {
       switch (error.code) {
+        case NOTE_SIZE_ERROR_CODE:
+          toast.error(
+            error.message === INLINE_IMAGE_DB_ERROR
+              ? INLINE_IMAGE_ERROR_MESSAGE
+              : NOTE_SIZE_ERROR_MESSAGE
+          );
+          return;
         case CHECK_VIOLATION_ERROR_CODE:
           toast.error(
             `This note cannot have an empty title. Please use a different title.`
@@ -158,6 +203,18 @@ function Note(props: Props) {
         <p className="text-2xl">{STRINGS.error.notePermissionError}</p>
       </div>
     );
+  }
+
+  if (contentLoadFailed) {
+    return (
+      <div className={errorContainerClassName}>
+        <p className="text-2xl">{STRINGS.error.notePermissionError}</p>
+      </div>
+    );
+  }
+
+  if (!isContentLoaded) {
+    return <PageLoading />;
   }
 
   return (

--- a/components/editor/PublishMenuContent.tsx
+++ b/components/editor/PublishMenuContent.tsx
@@ -4,9 +4,8 @@ import {
   IconArrowUpCircle,
   IconCircleCheck,
 } from '@tabler/icons';
-import { PostgrestSingleResponse } from '@supabase/supabase-js';
 import updateNote from 'lib/api/updateNote';
-import { Note, Visibility } from 'types/supabase';
+import { Visibility } from 'types/supabase';
 import { NoteTreeItem, store, useStore } from 'lib/store';
 import { useAuth } from 'utils/useAuth';
 import Tooltip from 'components/Tooltip';
@@ -190,8 +189,8 @@ const publishNestedNotes = async (
 
 const publishNestedNotesImpl = (
   noteTreeItem: NoteTreeItem,
-  promises: Promise<PostgrestSingleResponse<Note>>[]
-): Promise<PostgrestSingleResponse<Note>>[] => {
+  promises: Promise<unknown>[]
+): Promise<unknown>[] => {
   const promise = updateNote({
     id: noteTreeItem.id,
     visibility: Visibility.Public,

--- a/components/editor/blockmenu/BacklinksPopover.tsx
+++ b/components/editor/blockmenu/BacklinksPopover.tsx
@@ -58,7 +58,7 @@ export default function BacklinksPopover(props: BacklinksPopoverProps) {
       prevSavedElementText.current !== currentElementText
     ) {
       const handler = setTimeout(() => {
-        updateBlockBacklinks(blockBacklinks, currentElementText);
+        updateBlockBacklinks(element.id, blockBacklinks, currentElementText);
         prevSavedElementText.current = currentElementText;
       }, UPDATE_BLOCK_BACKLINKS_DEBOUNCE_MS);
 
@@ -66,7 +66,7 @@ export default function BacklinksPopover(props: BacklinksPopoverProps) {
         clearTimeout(handler);
       };
     }
-  }, [numOfMatches, currentElementText, blockBacklinks]);
+  }, [numOfMatches, currentElementText, blockBacklinks, element.id]);
 
   return numOfMatches > 0 ? (
     <Popover as={Fragment}>

--- a/components/editor/elements/BlockRefElement.tsx
+++ b/components/editor/elements/BlockRefElement.tsx
@@ -26,7 +26,7 @@ export default function BlockRefElement(props: BlockRefElementProps) {
   const selected = useSelected();
   const focused = useFocused();
 
-  const blockReference = useBlockReference(element.blockId);
+  const { blockReference, isLoading } = useBlockReference(element.blockId);
   const currentNote = useCurrentNote();
   const { onClick: onBlockRefClick, defaultStackingBehavior } =
     useOnNoteLinkClick(currentNote.id);
@@ -77,6 +77,8 @@ export default function BlockRefElement(props: BlockRefElementProps) {
             renderElement={renderElement}
             renderLeaf={EditorLeaf}
           />
+        ) : isLoading ? (
+          <div contentEditable={false}>{Node.string(element)}</div>
         ) : (
           <BlockRefError element={element} />
         )}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -55,7 +55,10 @@ Cypress.Commands.add('setup', () => {
         user_id: user?.id,
       }));
       // insert completed notes to supabase
-      await supabase.from('notes').insert(data);
+      const { error } = await supabase.from('notes').insert(data);
+      if (error) {
+        throw error;
+      }
     });
 
   cy.visit('/app');

--- a/editor/backlinks/deleteBacklinks.ts
+++ b/editor/backlinks/deleteBacklinks.ts
@@ -4,24 +4,31 @@ import { Note } from 'types/supabase';
 import supabase from 'lib/supabase';
 import { store } from 'lib/store';
 import { getActiveOrTempEditor } from 'lib/activeEditorsStore';
+import loadNotesContent from 'lib/api/loadNotesContent';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 import { computeLinkedBacklinks } from './useBacklinks';
 
 /**
  * Deletes the backlinks on each backlinked note and replaces them with the link text.
  */
 const deleteBacklinks = async (noteId: string) => {
-  const notes = store.getState().notes;
+  await loadBacklinkIndex();
+  const notes = store.getState().backlinkNotes;
   const backlinks = computeLinkedBacklinks(notes, noteId);
+  const contents = await loadNotesContent(
+    backlinks.map((backlink) => backlink.id)
+  );
   const updateData: Pick<Note, 'id' | 'content'>[] = [];
 
   for (const backlink of backlinks) {
     const note = notes[backlink.id];
 
-    if (!note) {
+    const content = contents.get(backlink.id);
+    if (!note || !content) {
       continue;
     }
 
-    const editor = getActiveOrTempEditor(backlink.id, note.content);
+    const editor = getActiveOrTempEditor(backlink.id, content);
 
     Transforms.unwrapNodes(editor, {
       at: [],

--- a/editor/backlinks/deleteBlockBacklinks.ts
+++ b/editor/backlinks/deleteBlockBacklinks.ts
@@ -4,13 +4,19 @@ import { computeBlockBacklinks } from 'editor/backlinks/useBlockBacklinks';
 import { store } from 'lib/store';
 import supabase from 'lib/supabase';
 import { Note } from 'types/supabase';
+import loadNotesContent from 'lib/api/loadNotesContent';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 
 /**
  * Deletes the block references/backlinks on each backlinked note and replaces them with referenced block text.
  */
 const deleteBlockBacklinks = async (editor: Editor, blockId: string) => {
-  const notes = store.getState().notes;
+  await loadBacklinkIndex();
+  const notes = store.getState().backlinkNotes;
   const backlinks = computeBlockBacklinks(notes)[blockId] ?? [];
+  const contents = await loadNotesContent(
+    backlinks.map((backlink) => backlink.id)
+  );
 
   // Update the block refs in the current editor to be paragraphs
   const updatedNodes = [];
@@ -30,7 +36,9 @@ const deleteBlockBacklinks = async (editor: Editor, blockId: string) => {
   const updateData: Pick<Note, 'id' | 'content'>[] = [];
   backlinks: for (const backlink of backlinks) {
     const noteEditor = createEditor();
-    noteEditor.children = notes[backlink.id].content;
+    const content = contents.get(backlink.id);
+    if (!content) continue;
+    noteEditor.children = content;
 
     for (const match of backlink.matches) {
       // Replace each block reference with a paragraph

--- a/editor/backlinks/updateBacklinks.ts
+++ b/editor/backlinks/updateBacklinks.ts
@@ -3,6 +3,8 @@ import { ElementType } from 'types/slate';
 import { Note } from 'types/supabase';
 import { store } from 'lib/store';
 import updateNote from 'lib/api/updateNote';
+import loadNotesContent from 'lib/api/loadNotesContent';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 import { getActiveOrTempEditor } from 'lib/activeEditorsStore';
 import { computeLinkedBacklinks } from './useBacklinks';
 
@@ -11,18 +13,23 @@ import { computeLinkedBacklinks } from './useBacklinks';
  * current note title has changed.
  */
 const updateBacklinks = async (newTitle: string, noteId: string) => {
-  const notes = store.getState().notes;
-  const backlinks = computeLinkedBacklinks(notes, noteId);
+  await loadBacklinkIndex();
+  const backlinkNotes = store.getState().backlinkNotes;
+  const backlinks = computeLinkedBacklinks(backlinkNotes, noteId);
+  const backlinkIds = backlinks.map((backlink) => backlink.id);
+  if (backlinkIds.length === 0) return;
+  const contents = await loadNotesContent(backlinkIds);
   const updateData: Pick<Note, 'id' | 'content'>[] = [];
 
   for (const backlink of backlinks) {
-    const note = notes[backlink.id];
+    const note = backlinkNotes[backlink.id];
+    const content = contents.get(backlink.id);
 
-    if (!note) {
+    if (!note || !content) {
       continue;
     }
 
-    const editor = getActiveOrTempEditor(backlink.id, note.content);
+    const editor = getActiveOrTempEditor(backlink.id, content);
 
     Transforms.setNodes(
       editor,

--- a/editor/backlinks/updateBlockBacklinks.ts
+++ b/editor/backlinks/updateBlockBacklinks.ts
@@ -4,6 +4,8 @@ import supabase from 'lib/supabase';
 import { store } from 'lib/store';
 import { getActiveOrTempEditor } from 'lib/activeEditorsStore';
 import { ElementType } from 'types/slate';
+import loadNotesContent from 'lib/api/loadNotesContent';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 import { Backlink } from './useBacklinks';
 
 /**
@@ -11,20 +13,26 @@ import { Backlink } from './useBacklinks';
  * full-text search.
  */
 const updateBlockBacklinks = async (
+  blockId: string,
   blockBacklinks: Backlink[],
   newText: string
 ) => {
-  const notes = store.getState().notes;
+  await loadBacklinkIndex();
+  const notes = store.getState().backlinkNotes;
+  const contents = await loadNotesContent(
+    blockBacklinks.map((backlink) => backlink.id)
+  );
   const updateData: Pick<Note, 'id' | 'content'>[] = [];
 
   for (const backlink of blockBacklinks) {
     const note = notes[backlink.id];
 
-    if (!note) {
+    const content = contents.get(backlink.id);
+    if (!note || !content) {
       continue;
     }
 
-    const editor = getActiveOrTempEditor(backlink.id, note.content);
+    const editor = getActiveOrTempEditor(backlink.id, content);
 
     Transforms.setNodes(
       editor,
@@ -35,7 +43,7 @@ const updateBlockBacklinks = async (
           !Editor.isEditor(n) &&
           Element.isElement(n) &&
           n.type === ElementType.BlockReference &&
-          n.blockId === backlink.id,
+          n.blockId === blockId,
         voids: true,
       }
     );

--- a/editor/backlinks/useBacklinks.ts
+++ b/editor/backlinks/useBacklinks.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import {
   createEditor,
   Editor,
@@ -13,6 +13,7 @@ import type { Notes } from 'lib/store';
 import { useStore } from 'lib/store';
 import useDebounce from 'utils/useDebounce';
 import { caseInsensitiveStringEqual } from 'utils/string';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 
 const DEBOUNCE_MS = 1000;
 
@@ -36,8 +37,11 @@ export type Backlink = {
 };
 
 export default function useBacklinks(noteId: string) {
+  useEffect(() => {
+    loadBacklinkIndex();
+  }, []);
   const [notes] = useDebounce(
-    useStore((state) => state.notes),
+    useStore((state) => state.backlinkNotes),
     DEBOUNCE_MS
   );
 

--- a/editor/backlinks/useBlockBacklinks.ts
+++ b/editor/backlinks/useBlockBacklinks.ts
@@ -3,13 +3,17 @@ import { createEditor, Editor, Element } from 'slate';
 import { Notes, useStore } from 'lib/store';
 import useDebounce from 'utils/useDebounce';
 import { BlockReference, ElementType } from 'types/slate';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 import { Backlink, BacklinkType } from './useBacklinks';
 
 const DEBOUNCE_MS = 1000;
 
 export default function useBlockBacklinks() {
+  useEffect(() => {
+    loadBacklinkIndex();
+  }, []);
   const [notes] = useDebounce(
-    useStore((state) => state.notes),
+    useStore((state) => state.backlinkNotes),
     DEBOUNCE_MS
   );
 

--- a/editor/backlinks/useBlockReference.ts
+++ b/editor/backlinks/useBlockReference.ts
@@ -1,12 +1,11 @@
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { createEditor, Editor, Element, Path } from 'slate';
 import type { Notes } from 'lib/store';
 import { useStore } from 'lib/store';
-import useDebounce from 'utils/useDebounce';
 import { Note } from 'types/supabase';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
+import useIsPublish from 'utils/useIsPublish';
 import { isReferenceableBlockElement } from '../checks';
-
-const DEBOUNCE_MS = 500;
 
 export type BlockReference = {
   noteId: string;
@@ -15,11 +14,18 @@ export type BlockReference = {
 };
 
 export default function useBlockReference(blockId: string) {
-  const [notes] = useDebounce(
-    useStore((state) => state.notes),
-    DEBOUNCE_MS
+  const isPublish = useIsPublish();
+  const notes = useStore((state) =>
+    isPublish ? state.notes : state.backlinkNotes
+  );
+  const isBacklinkIndexLoaded = useStore(
+    (state) => state.isBacklinkIndexLoaded
   );
   const cachedPath = useRef<{ noteId: string; path: Path } | null>(null);
+
+  useEffect(() => {
+    if (!isPublish) loadBacklinkIndex();
+  }, [isPublish]);
 
   /**
    * Searches the notes array for the specific block reference and returns it.
@@ -46,7 +52,10 @@ export default function useBlockReference(blockId: string) {
     return blockRef;
   }, [notes, blockId]);
 
-  return blockReference;
+  return {
+    blockReference,
+    isLoading: !isPublish && !isBacklinkIndexLoaded,
+  };
 }
 
 /**

--- a/editor/normalizeInlineImages.ts
+++ b/editor/normalizeInlineImages.ts
@@ -1,0 +1,38 @@
+import { Element, type Descendant } from 'slate';
+import { ElementType, type Image } from 'types/slate';
+import { uploadImage } from './plugins/withImages';
+
+const DATA_IMAGE_PATTERN = /^data:(image\/[a-z0-9.+-]+);base64,/i;
+
+const dataUrlToFile = async (url: string) => {
+  const match = url.match(DATA_IMAGE_PATTERN);
+  if (!match) return null;
+  const blob = await fetch(url).then((response) => response.blob());
+  const extension = match[1].split('/')[1] || 'png';
+  return new File([blob], `pasted-image.${extension}`, { type: match[1] });
+};
+
+export const normalizeInlineImages = async (
+  nodes: Descendant[]
+): Promise<Descendant[]> =>
+  Promise.all(
+    nodes.map(async (node): Promise<Descendant> => {
+      if (!Element.isElement(node)) return node;
+
+      let normalized = node;
+      if (
+        node.type === ElementType.Image &&
+        DATA_IMAGE_PATTERN.test(node.url)
+      ) {
+        const file = await dataUrlToFile(node.url);
+        const url = file ? await uploadImage(file) : null;
+        if (!url) throw new Error('The embedded image could not be uploaded.');
+        normalized = { ...node, url } as Image;
+      }
+
+      return {
+        ...normalized,
+        children: await normalizeInlineImages(normalized.children),
+      } as Descendant;
+    })
+  );

--- a/editor/plugins/withHtml.ts
+++ b/editor/plugins/withHtml.ts
@@ -1,7 +1,9 @@
-import { Editor, Element, Node, Transforms } from 'slate';
+import { Descendant, Editor, Element, Node, Transforms } from 'slate';
 import { jsx } from 'slate-hyperscript';
+import { toast } from 'react-toastify';
 import { ElementType, Mark } from 'types/slate';
 import { PickPartial } from 'types/utils';
+import { normalizeInlineImages } from 'editor/normalizeInlineImages';
 
 const ELEMENT_TAGS: Record<
   string,
@@ -113,6 +115,17 @@ const withHtml = (editor: Editor) => {
     // We can't currently differentiate between different editors; see https://github.com/ianstormtaylor/slate/issues/1024
     if (html && !isSlateFragment) {
       const parsed = new DOMParser().parseFromString(html, 'text/html');
+      if (parsed.querySelector('img[src^="data:image/"]')) {
+        const fragment = deserialize(parsed.body) as Descendant[];
+        normalizeInlineImages(fragment)
+          .then((normalized) => Transforms.insertFragment(editor, normalized))
+          .catch(() =>
+            toast.error(
+              'The pasted image could not be uploaded. Please try again.'
+            )
+          );
+        return;
+      }
       const fragment = deserialize(parsed.body);
       Transforms.insertFragment(editor, fragment);
       return;

--- a/editor/plugins/withImages.ts
+++ b/editor/plugins/withImages.ts
@@ -52,13 +52,18 @@ export const uploadAndInsertImage = async (
   file: File,
   path?: Path
 ) => {
+  const signedUrl = await uploadImage(file);
+  if (signedUrl) insertImage(editor, signedUrl, path);
+};
+
+export const uploadImage = async (file: File): Promise<string | null> => {
   const {
     data: { session },
   } = await supabase.auth.getSession();
   const user = session?.user;
 
   if (!user) {
-    return;
+    return null;
   }
 
   // Enforce upload limits
@@ -70,7 +75,7 @@ export const uploadAndInsertImage = async (
     toast.error(
       'Your image is over the 5 MB limit. Upgrade to the Pro plan for 20 MB file uploads.'
     );
-    return;
+    return null;
   } else if (
     (planId === PlanId.Pro || planId === PlanId.Catalyst) &&
     file.size > PRO_UPLOAD_LIMIT
@@ -78,7 +83,7 @@ export const uploadAndInsertImage = async (
     toast.error(
       'Your image is over the 20 MB limit. Please upload a smaller image.'
     );
-    return;
+    return null;
   }
 
   const uploadingToast = toast.info('Uploading image, please wait...', {
@@ -94,7 +99,7 @@ export const uploadAndInsertImage = async (
   if (uploadError) {
     toast.dismiss(uploadingToast);
     toast.error(uploadError.message);
-    return;
+    return null;
   }
 
   const expiresIn = 60 * 60 * 24 * 365 * 100; // 100 year expiry
@@ -105,7 +110,7 @@ export const uploadAndInsertImage = async (
 
   toast.dismiss(uploadingToast);
   if (signedUrl) {
-    insertImage(editor, signedUrl, path);
+    return signedUrl;
   } else if (signedUrlError) {
     toast.error(signedUrlError.message);
   } else {
@@ -113,6 +118,7 @@ export const uploadAndInsertImage = async (
       'There was a problem uploading your image. Please try again later.'
     );
   }
+  return null;
 };
 
 export default withImages;

--- a/lib/api/loadBacklinkIndex.ts
+++ b/lib/api/loadBacklinkIndex.ts
@@ -1,0 +1,72 @@
+import supabase from 'lib/supabase';
+import { store } from 'lib/store';
+import type { Note } from 'types/supabase';
+
+let pendingLoad: Promise<void> | null = null;
+
+const rowToNote = (row: {
+  note_id: string;
+  user_id: string;
+  title: string;
+  content: Note['content'];
+}) =>
+  ({
+    id: row.note_id,
+    user_id: row.user_id,
+    title: row.title,
+    content: row.content,
+    created_at: '',
+    updated_at: '',
+    visibility: 'private',
+  } as Note);
+
+/**
+ * Refreshes a single note in the backlink index cache, e.g. after a realtime
+ * update from another client. No-op if the index hasn't been loaded yet.
+ */
+export async function refreshBacklinkNote(noteId: string) {
+  if (!store.getState().isBacklinkIndexLoaded) return;
+
+  const { data, error } = await supabase
+    .from('note_backlink_index')
+    .select('note_id, user_id, title, content')
+    .eq('note_id', noteId)
+    .maybeSingle();
+
+  if (error || !data) return;
+
+  store.getState().setBacklinkNotes((backlinkNotes) => ({
+    ...backlinkNotes,
+    [data.note_id]: {
+      ...(backlinkNotes[data.note_id] ?? rowToNote(data)),
+      title: data.title,
+      content: data.content,
+    },
+  }));
+}
+
+export default function loadBacklinkIndex() {
+  if (store.getState().isBacklinkIndexLoaded) return Promise.resolve();
+  if (pendingLoad) return pendingLoad;
+
+  pendingLoad = Promise.resolve(
+    supabase
+      .from('note_backlink_index')
+      .select('note_id, user_id, title, content')
+  )
+    .then(({ data, error }) => {
+      if (!error && data) {
+        const notes = data.reduce<Record<string, Note>>((result, row) => {
+          result[row.note_id] = rowToNote(row);
+          return result;
+        }, {});
+        store.getState().setBacklinkNotes(notes);
+        store.getState().setIsBacklinkIndexLoaded(true);
+      }
+    })
+    .finally(() => {
+      pendingLoad = null;
+    });
+
+  return pendingLoad;
+}

--- a/lib/api/loadNoteContent.ts
+++ b/lib/api/loadNoteContent.ts
@@ -1,0 +1,25 @@
+import supabase from 'lib/supabase';
+import { store } from 'lib/store';
+
+const pendingLoads = new Map<string, Promise<boolean>>();
+
+export default function loadNoteContent(noteId: string) {
+  const existing = pendingLoads.get(noteId);
+  if (existing) return existing;
+
+  const request = Promise.resolve(
+    supabase.from('notes').select('content').eq('id', noteId).single()
+  )
+    .then(({ data, error }) => {
+      if (!error && data) {
+        store.getState().updateNote({ id: noteId, content: data.content });
+        store.getState().setNoteContentLoaded(noteId, true);
+        return true;
+      }
+      return false;
+    })
+    .finally(() => pendingLoads.delete(noteId));
+
+  pendingLoads.set(noteId, request);
+  return request;
+}

--- a/lib/api/loadNotesContent.ts
+++ b/lib/api/loadNotesContent.ts
@@ -1,0 +1,12 @@
+import supabase from 'lib/supabase';
+import type { Note } from 'types/supabase';
+
+export default async function loadNotesContent(noteIds: string[]) {
+  if (noteIds.length === 0) return new Map<Note['id'], Note['content']>();
+  const { data, error } = await supabase
+    .from('notes')
+    .select('id, content')
+    .in('id', noteIds);
+  if (error) throw error;
+  return new Map(data.map((note) => [note.id, note.content]));
+}

--- a/lib/api/updateNote.ts
+++ b/lib/api/updateNote.ts
@@ -2,6 +2,11 @@ import type { PickPartial } from 'types/utils';
 import supabase from 'lib/supabase';
 import type { Note } from 'types/supabase';
 import { store } from 'lib/store';
+import {
+  hasInlineImageData,
+  INLINE_IMAGE_DB_ERROR,
+  NOTE_SIZE_ERROR_CODE,
+} from 'lib/noteContent';
 
 export type NoteUpdate = PickPartial<
   Note,
@@ -9,11 +14,19 @@ export type NoteUpdate = PickPartial<
 >;
 
 export default async function updateNote(note: NoteUpdate) {
+  // The size limit is deliberately left to the database trigger, which allows
+  // grandfathered oversized notes to shrink back under the limit
+  if (note.content && hasInlineImageData(note.content)) {
+    return {
+      data: null,
+      error: { code: NOTE_SIZE_ERROR_CODE, message: INLINE_IMAGE_DB_ERROR },
+    };
+  }
   const response = await supabase
     .from('notes')
     .update({ ...note, updated_at: new Date().toISOString() })
     .eq('id', note.id)
-    .select()
+    .select('id, updated_at, visibility')
     .single();
 
   if (response.data) {

--- a/lib/api/upsertNote.ts
+++ b/lib/api/upsertNote.ts
@@ -2,6 +2,8 @@ import { store } from 'lib/store';
 import supabase from 'lib/supabase';
 import type { NoteInsert } from 'types/supabase';
 import type { PickPartial } from 'types/utils';
+import { validateNoteContent } from 'lib/noteContent';
+import { getDefaultEditorValue } from 'editor/constants';
 
 type NoteUpsert = PickPartial<
   NoteInsert,
@@ -9,6 +11,10 @@ type NoteUpsert = PickPartial<
 >;
 
 export default async function upsertNote(note: NoteUpsert) {
+  if (note.content) {
+    const message = validateNoteContent(note.content);
+    if (message) throw new Error(message);
+  }
   const {
     data: { session },
   } = await supabase.auth.getSession();
@@ -24,12 +30,16 @@ export default async function upsertNote(note: NoteUpsert) {
       { ...note, user_id: userId, updated_at: new Date().toISOString() },
       { onConflict: 'user_id, title' }
     )
-    .select()
+    .select('id, user_id, title, created_at, updated_at, visibility')
     .single();
 
   // Refreshes the list of notes in the sidebar
   if (data) {
-    store.getState().upsertNote(data);
+    store.getState().upsertNote({
+      ...data,
+      content: note.content ?? getDefaultEditorValue(),
+    });
+    store.getState().setNoteContentLoaded(data.id, true);
     await supabase
       .from('users')
       .update({ note_tree: store.getState().noteTree })

--- a/lib/noteContent.ts
+++ b/lib/noteContent.ts
@@ -1,0 +1,38 @@
+import type { Descendant } from 'slate';
+
+export const MAX_NOTE_BYTES = 5 * 1024 * 1024;
+export const NOTE_WARNING_BYTES = Math.floor(4.5 * 1024 * 1024);
+export const NOTE_SIZE_ERROR_CODE = 'P0001';
+// Messages raised by the validate_note_content trigger in the database
+export const NOTE_SIZE_DB_ERROR = 'NOTE_CONTENT_TOO_LARGE';
+export const INLINE_IMAGE_DB_ERROR = 'NOTE_CONTAINS_INLINE_IMAGE';
+export const NOTE_SIZE_ERROR_MESSAGE =
+  'This note is over the 5 MB limit. Remove some content or upload embedded images as files before saving.';
+export const INLINE_IMAGE_ERROR_MESSAGE =
+  'This note contains an embedded image. Upload the image as a file before saving.';
+
+export const getNoteContentBytes = (content: Descendant[]) =>
+  new Blob([JSON.stringify(content)]).size;
+
+export const hasInlineImageData = (value: unknown): boolean => {
+  if (typeof value === 'string') {
+    return /^data:image\/[a-z0-9.+-]+;base64,/i.test(value);
+  }
+  if (Array.isArray(value)) {
+    return value.some(hasInlineImageData);
+  }
+  if (value && typeof value === 'object') {
+    return Object.values(value).some(hasInlineImageData);
+  }
+  return false;
+};
+
+export const validateNoteContent = (content: Descendant[]) => {
+  if (hasInlineImageData(content)) {
+    return INLINE_IMAGE_ERROR_MESSAGE;
+  }
+  if (getNoteContentBytes(content) > MAX_NOTE_BYTES) {
+    return NOTE_SIZE_ERROR_MESSAGE;
+  }
+  return null;
+};

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -95,6 +95,13 @@ export type Store = {
   upsertNote: (note: Note) => void;
   updateNote: (note: NoteUpdate) => void;
   deleteNote: (noteId: string) => void;
+  loadedNoteContent: Record<string, boolean>;
+  setLoadedNoteContent: Setter<Record<string, boolean>>;
+  setNoteContentLoaded: (noteId: string, loaded: boolean) => void;
+  backlinkNotes: Notes;
+  setBacklinkNotes: Setter<Notes>;
+  isBacklinkIndexLoaded: boolean;
+  setIsBacklinkIndexLoaded: Setter<boolean>;
   openNoteIds: string[];
   setOpenNoteIds: (openNoteIds: string[], index?: number) => void;
   noteTree: NoteTreeItem[];
@@ -132,6 +139,12 @@ export const store = createStore<Store>()(
        */
       upsertNote: (note: Note) => {
         set((state) => {
+          if (state.isBacklinkIndexLoaded) {
+            state.backlinkNotes[note.id] = {
+              ...(state.backlinkNotes[note.id] ?? note),
+              ...note,
+            };
+          }
           if (state.notes[note.id]) {
             state.notes[note.id] = { ...state.notes[note.id], ...note };
           } else {
@@ -164,6 +177,12 @@ export const store = createStore<Store>()(
           if (state.notes[note.id]) {
             state.notes[note.id] = { ...state.notes[note.id], ...note };
           }
+          if (state.backlinkNotes[note.id]) {
+            state.backlinkNotes[note.id] = {
+              ...state.backlinkNotes[note.id],
+              ...note,
+            };
+          }
         });
       },
       /**
@@ -172,6 +191,7 @@ export const store = createStore<Store>()(
       deleteNote: (noteId: string) => {
         set((state) => {
           delete state.notes[noteId];
+          delete state.backlinkNotes[noteId];
           const item = deleteTreeItem(state.noteTree, noteId);
           if (item && item.children.length > 0) {
             for (const child of item.children) {
@@ -180,6 +200,17 @@ export const store = createStore<Store>()(
           }
         });
       },
+      loadedNoteContent: {},
+      setLoadedNoteContent: createSetter(set, 'loadedNoteContent'),
+      setNoteContentLoaded: (noteId, loaded) => {
+        set((state) => {
+          state.loadedNoteContent[noteId] = loaded;
+        });
+      },
+      backlinkNotes: {},
+      setBacklinkNotes: createSetter(set, 'backlinkNotes'),
+      isBacklinkIndexLoaded: false,
+      setIsBacklinkIndexLoaded: createSetter(set, 'isBacklinkIndexLoaded'),
       /**
        * The notes that have their content visible, including the main note and the stacked notes
        */

--- a/pages/app/graph.tsx
+++ b/pages/app/graph.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import Head from 'next/head';
 import { createEditor, Editor, Element, Node } from 'slate';
 import type { NoteLink } from 'types/slate';
@@ -8,10 +8,14 @@ import ForceGraph from 'components/ForceGraph';
 import { useStore } from 'lib/store';
 import ErrorBoundary from 'components/ErrorBoundary';
 import OpenSidebarButton from 'components/sidebar/OpenSidebarButton';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 
 export default function Graph() {
-  const notes = useStore((state) => state.notes);
+  const notes = useStore((state) => state.backlinkNotes);
   const isSidebarOpen = useStore((state) => state.isSidebarOpen);
+  useEffect(() => {
+    loadBacklinkIndex();
+  }, []);
 
   // Compute graph data
   const graphData: GraphData = useMemo(() => {

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -210,3 +210,6 @@ CREATE TRIGGER refresh_note_backlink_index
   FOR EACH ROW EXECUTE FUNCTION public.refresh_note_backlink_index();
 
 GRANT SELECT ON public.note_backlink_index TO authenticated;
+
+GRANT ALL ON public.notes, public.users, public.subscriptions TO authenticated;
+GRANT SELECT ON public.notes, public.users TO anon;

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -19,6 +19,7 @@ CREATE TYPE visibility AS ENUM ('private', 'public');
 
 -- public.notes definition
 
+DROP TABLE IF EXISTS public.note_backlink_index;
 DROP TABLE IF EXISTS public.notes;
 CREATE TABLE public.notes (
   "content" jsonb NOT NULL DEFAULT (('[ { "id": "'::text || extensions.uuid_generate_v4()) || '", "type": "paragraph", "children": [{ "text": "" }] } ]'::text)::jsonb,
@@ -148,3 +149,64 @@ drop trigger if exists on_public_user_created on public.users;
 create trigger on_public_user_created
   after insert on public.users
   for each row execute function create_onboarding_notes();
+
+
+-- backlink index
+
+CREATE TABLE public.note_backlink_index (
+  note_id uuid PRIMARY KEY REFERENCES public.notes(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  title citext NOT NULL,
+  content jsonb NOT NULL DEFAULT '[]'::jsonb,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.note_backlink_index ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can read their own backlink index"
+  ON public.note_backlink_index FOR SELECT
+  USING (auth.uid() = user_id);
+
+CREATE OR REPLACE FUNCTION public.backlink_safe_json(value jsonb)
+RETURNS jsonb
+LANGUAGE sql
+IMMUTABLE
+SET search_path = public
+AS $$
+  SELECT regexp_replace(
+    value::text,
+    '"data:image/[a-z0-9.+-]+;base64,[^\"]*"',
+    '""',
+    'gi'
+  )::jsonb;
+$$;
+
+CREATE OR REPLACE FUNCTION public.refresh_note_backlink_index()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.note_backlink_index (note_id, user_id, title, content, updated_at)
+  VALUES (
+    new.id,
+    new.user_id,
+    new.title,
+    public.backlink_safe_json(new.content),
+    new.updated_at
+  )
+  ON CONFLICT (note_id) DO UPDATE SET
+    user_id = excluded.user_id,
+    title = excluded.title,
+    content = excluded.content,
+    updated_at = excluded.updated_at;
+  RETURN new;
+END;
+$$;
+
+CREATE TRIGGER refresh_note_backlink_index
+  AFTER INSERT OR UPDATE OF title, content ON public.notes
+  FOR EACH ROW EXECUTE FUNCTION public.refresh_note_backlink_index();
+
+GRANT SELECT ON public.note_backlink_index TO authenticated;

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -19,7 +19,7 @@ max_rows = 1000
 port = 54322
 # The database major version to use. This has to be the same as your remote database's. Run `SHOW
 # server_version;` on the remote database to check.
-major_version = 14
+major_version = 15
 
 [studio]
 # Port to use for Supabase Studio.

--- a/supabase/migrations/20260710190000_note_backlink_index.sql
+++ b/supabase/migrations/20260710190000_note_backlink_index.sql
@@ -1,7 +1,7 @@
 create table if not exists public.note_backlink_index (
   note_id uuid primary key references public.notes(id) on delete cascade,
   user_id uuid not null references auth.users(id) on delete cascade,
-  title citext not null,
+  title extensions.citext not null,
   content jsonb not null default '[]'::jsonb,
   updated_at timestamptz not null default now()
 );

--- a/supabase/migrations/20260710190000_note_backlink_index.sql
+++ b/supabase/migrations/20260710190000_note_backlink_index.sql
@@ -1,0 +1,70 @@
+create table if not exists public.note_backlink_index (
+  note_id uuid primary key references public.notes(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  title citext not null,
+  content jsonb not null default '[]'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+alter table public.note_backlink_index enable row level security;
+
+create policy "Users can read their own backlink index"
+  on public.note_backlink_index for select
+  using (auth.uid() = user_id);
+
+create or replace function public.backlink_safe_json(value jsonb)
+returns jsonb
+language sql
+immutable
+set search_path = public
+as $$
+  select regexp_replace(
+    value::text,
+    '"data:image/[a-z0-9.+-]+;base64,[^\"]*"',
+    '""',
+    'gi'
+  )::jsonb;
+$$;
+
+create or replace function public.refresh_note_backlink_index()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into public.note_backlink_index (note_id, user_id, title, content, updated_at)
+  values (
+    new.id,
+    new.user_id,
+    new.title,
+    public.backlink_safe_json(new.content),
+    new.updated_at
+  )
+  on conflict (note_id) do update set
+    user_id = excluded.user_id,
+    title = excluded.title,
+    content = excluded.content,
+    updated_at = excluded.updated_at;
+  return new;
+end;
+$$;
+
+drop trigger if exists refresh_note_backlink_index on public.notes;
+create trigger refresh_note_backlink_index
+  after insert or update of title, content on public.notes
+  for each row execute function public.refresh_note_backlink_index();
+
+insert into public.note_backlink_index (note_id, user_id, title, content, updated_at)
+select id, user_id, title, public.backlink_safe_json(content), updated_at
+from public.notes
+on conflict (note_id) do update set
+  user_id = excluded.user_id,
+  title = excluded.title,
+  content = excluded.content,
+  updated_at = excluded.updated_at;
+
+create index if not exists note_backlink_index_user_id_idx
+  on public.note_backlink_index(user_id);
+
+grant select on public.note_backlink_index to authenticated;

--- a/supabase/migrations/20260710190000_note_backlink_index.sql
+++ b/supabase/migrations/20260710190000_note_backlink_index.sql
@@ -1,9 +1,9 @@
-create extension if not exists citext with schema extensions;
+create extension if not exists citext with schema public;
 
 create table if not exists public.note_backlink_index (
   note_id uuid primary key references public.notes(id) on delete cascade,
   user_id uuid not null references auth.users(id) on delete cascade,
-  title extensions.citext not null,
+  title public.citext not null,
   content jsonb not null default '[]'::jsonb,
   updated_at timestamptz not null default now()
 );

--- a/supabase/migrations/20260710190000_note_backlink_index.sql
+++ b/supabase/migrations/20260710190000_note_backlink_index.sql
@@ -1,3 +1,5 @@
+create extension if not exists citext with schema extensions;
+
 create table if not exists public.note_backlink_index (
   note_id uuid primary key references public.notes(id) on delete cascade,
   user_id uuid not null references auth.users(id) on delete cascade,

--- a/supabase/migrations/20260710191000_note_content_validation_functions.sql
+++ b/supabase/migrations/20260710191000_note_content_validation_functions.sql
@@ -1,0 +1,58 @@
+create or replace function public.compact_jsonb_size(value jsonb)
+returns bigint
+language plpgsql
+immutable
+set search_path = public
+as $$
+declare
+  result bigint;
+  item_count bigint;
+begin
+  if jsonb_typeof(value) = 'array' then
+    select coalesce(sum(public.compact_jsonb_size(item)), 0), count(*)
+      into result, item_count
+      from jsonb_array_elements(value) item;
+    return 2 + result + greatest(item_count - 1, 0);
+  end if;
+
+  if jsonb_typeof(value) = 'object' then
+    select coalesce(
+      sum(
+        octet_length(to_jsonb(key)::text)
+        + 1
+        + public.compact_jsonb_size(item)
+      ),
+      0
+    ), count(*)
+      into result, item_count
+      from jsonb_each(value) as fields(key, item);
+    return 2 + result + greatest(item_count - 1, 0);
+  end if;
+
+  return octet_length(value::text);
+end;
+$$;
+
+create or replace function public.validate_note_content_size()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if public.compact_jsonb_size(new.content) > 5 * 1024 * 1024 then
+    raise exception using
+      errcode = 'P0001',
+      message = 'NOTE_CONTENT_TOO_LARGE';
+  end if;
+
+  if new.content::text ~* 'data:image/[a-z0-9.+-]+;base64,' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'NOTE_CONTAINS_INLINE_IMAGE';
+  end if;
+
+  return new;
+end;
+$$;
+
+-- Enable this trigger only after the existing inline images have been migrated.

--- a/supabase/migrations/20260710192000_note_content_backups.sql
+++ b/supabase/migrations/20260710192000_note_content_backups.sql
@@ -1,0 +1,25 @@
+create table if not exists public.note_content_backups (
+  note_id uuid primary key references public.notes(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  content jsonb not null,
+  backed_up_at timestamptz not null default now()
+);
+
+alter table public.note_content_backups enable row level security;
+
+-- Backups are intentionally accessible only with the service role.
+revoke all on public.note_content_backups from anon, authenticated;
+
+create or replace function public.notes_with_inline_images()
+returns table(note_id uuid)
+language sql
+security definer
+set search_path = public
+as $$
+  select id
+  from public.notes
+  where content::text ~* 'data:image/[a-z0-9.+-]+;base64,';
+$$;
+
+revoke all on function public.notes_with_inline_images() from public, anon, authenticated;
+grant execute on function public.notes_with_inline_images() to service_role;

--- a/supabase/migrations/20260710193000_tighten_inline_image_detection.sql
+++ b/supabase/migrations/20260710193000_tighten_inline_image_detection.sql
@@ -1,0 +1,35 @@
+create or replace function public.validate_note_content_size()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if public.compact_jsonb_size(new.content) > 5 * 1024 * 1024 then
+    raise exception using
+      errcode = 'P0001',
+      message = 'NOTE_CONTENT_TOO_LARGE';
+  end if;
+
+  if new.content::text ~* '"data:image/[a-z0-9.+-]+;base64,' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'NOTE_CONTAINS_INLINE_IMAGE';
+  end if;
+
+  return new;
+end;
+$$;
+
+create or replace function public.notes_with_inline_images()
+returns table(note_id uuid)
+language sql
+security definer
+set search_path = public
+as $$
+  select id
+  from public.notes
+  where content::text ~* '"data:image/[a-z0-9.+-]+;base64,';
+$$;
+
+revoke all on function public.notes_with_inline_images() from public, anon, authenticated;
+grant execute on function public.notes_with_inline_images() to service_role;

--- a/supabase/migrations/20260710194000_non_recursive_note_size_validation.sql
+++ b/supabase/migrations/20260710194000_non_recursive_note_size_validation.sql
@@ -1,0 +1,21 @@
+create or replace function public.validate_note_content_size()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+begin
+  if octet_length(new.content::text) > 5 * 1024 * 1024 then
+    raise exception using
+      errcode = 'P0001',
+      message = 'NOTE_CONTENT_TOO_LARGE';
+  end if;
+
+  if new.content::text ~* '"data:image/[a-z0-9.+-]+;base64,' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'NOTE_CONTAINS_INLINE_IMAGE';
+  end if;
+
+  return new;
+end;
+$$;

--- a/supabase/migrations/20260710195000_grandfather_oversized_notes.sql
+++ b/supabase/migrations/20260710195000_grandfather_oversized_notes.sql
@@ -1,0 +1,29 @@
+create or replace function public.validate_note_content_size()
+returns trigger
+language plpgsql
+set search_path = public
+as $$
+declare
+  new_size bigint := octet_length(new.content::text);
+  old_size bigint := case
+    when tg_op = 'UPDATE' then octet_length(old.content::text)
+    else 0
+  end;
+begin
+  if new.content::text ~* '"data:image/[a-z0-9.+-]+;base64,' then
+    raise exception using
+      errcode = 'P0001',
+      message = 'NOTE_CONTAINS_INLINE_IMAGE';
+  end if;
+
+  if new_size > 5 * 1024 * 1024
+    and (tg_op = 'INSERT' or old_size <= 5 * 1024 * 1024 or new_size > old_size)
+  then
+    raise exception using
+      errcode = 'P0001',
+      message = 'NOTE_CONTENT_TOO_LARGE';
+  end if;
+
+  return new;
+end;
+$$;

--- a/supabase/migrations/20260710200000_enable_note_content_validation.sql
+++ b/supabase/migrations/20260710200000_enable_note_content_validation.sql
@@ -1,0 +1,16 @@
+do $$
+begin
+  if exists (
+    select 1
+    from public.notes
+    where content::text ~* '"data:image/[a-z0-9.+-]+;base64,'
+  ) then
+    raise exception 'Existing notes still contain inline images';
+  end if;
+end;
+$$;
+
+drop trigger if exists validate_note_content on public.notes;
+create trigger validate_note_content
+  before insert or update of content on public.notes
+  for each row execute function public.validate_note_content_size();

--- a/supabase/migrations/20260710201000_remove_completed_migration_helpers.sql
+++ b/supabase/migrations/20260710201000_remove_completed_migration_helpers.sql
@@ -1,0 +1,2 @@
+drop function if exists public.notes_with_inline_images();
+drop function if exists public.compact_jsonb_size(jsonb);

--- a/types/supabase.ts
+++ b/types/supabase.ts
@@ -53,6 +53,18 @@ export interface Database {
         };
         Relationships: [];
       };
+      note_backlink_index: {
+        Row: {
+          content: Descendant[];
+          note_id: string;
+          title: string;
+          updated_at: string;
+          user_id: string;
+        };
+        Insert: never;
+        Update: never;
+        Relationships: [];
+      };
       subscriptions: {
         Row: {
           cancel_at_period_end: boolean;
@@ -130,6 +142,10 @@ export interface Database {
       [_ in never]: never;
     };
     Functions: {
+      notes_with_inline_images: {
+        Args: Record<PropertyKey, never>;
+        Returns: { note_id: string }[];
+      };
       citext:
         | {
             Args: { '': string };

--- a/utils/useBlockSearch.ts
+++ b/utils/useBlockSearch.ts
@@ -1,10 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import Fuse from 'fuse.js';
 import { createEditor, Descendant, Editor, Element, Node, Path } from 'slate';
 import { Notes, store } from 'lib/store';
 import withLinks from 'editor/plugins/withLinks';
 import withVoidElements from 'editor/plugins/withVoidElements';
 import withTags from 'editor/plugins/withTags';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 
 export type NoteBlock = {
   id?: string;
@@ -23,9 +24,12 @@ type NoteSearchOptions = {
 export default function useBlockSearch({
   numOfResults = -1,
 }: NoteSearchOptions = {}) {
+  useEffect(() => {
+    loadBacklinkIndex();
+  }, []);
   const search = useCallback(
     (searchText: string) => {
-      const fuse = initFuse(store.getState().notes);
+      const fuse = initFuse(store.getState().backlinkNotes);
       return fuse.search(searchText, { limit: numOfResults });
     },
     [numOfResults]

--- a/utils/useDeleteNote.ts
+++ b/utils/useDeleteNote.ts
@@ -38,8 +38,8 @@ export default function useDeleteNote(noteId: string) {
       return;
     }
 
-    await deleteNote(user.id, noteId);
     await deleteBacklinks(noteId);
+    await deleteNote(user.id, noteId);
   }, [router, user, noteId, openNoteIds]);
 
   return onDeleteClick;

--- a/utils/useImport.ts
+++ b/utils/useImport.ts
@@ -14,6 +14,8 @@ import { caseInsensitiveStringEqual } from 'utils/string';
 import { ElementType, NoteLink } from 'types/slate';
 import { Note, NoteInsert } from 'types/supabase';
 import { Feature, MAX_NUM_OF_BASIC_NOTES, PlanId } from 'constants/pricing';
+import { normalizeInlineImages } from 'editor/normalizeInlineImages';
+import { validateNoteContent } from 'lib/noteContent';
 import { useAuth } from './useAuth';
 import useFeature from './useFeature';
 
@@ -161,8 +163,28 @@ export default function useImport() {
           .use(remarkToSlate)
           .processSync(fileContent);
 
-        const { content: slateContent, upsertData: newUpsertData } =
+        const { content: parsedContent, upsertData: newUpsertData } =
           fixNoteLinks(result as Descendant[], noteTitleToIdCache);
+        let slateContent;
+        try {
+          slateContent = await normalizeInlineImages(parsedContent);
+        } catch (error) {
+          toast.dismiss(importingToast);
+          toast.error(
+            `${file.name}: ${
+              error instanceof Error
+                ? error.message
+                : 'The embedded images could not be uploaded.'
+            }`
+          );
+          return;
+        }
+        const validationError = validateNoteContent(slateContent);
+        if (validationError) {
+          toast.dismiss(importingToast);
+          toast.error(`${file.name}: ${validationError}`);
+          return;
+        }
 
         noteLinkUpsertData.push(...newUpsertData);
         upsertData.push({

--- a/utils/useNoteSearch.ts
+++ b/utils/useNoteSearch.ts
@@ -1,10 +1,11 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import Fuse from 'fuse.js';
 import { createEditor, Descendant, Editor, Node, Path, Element } from 'slate';
 import { Notes, store } from 'lib/store';
 import withLinks from 'editor/plugins/withLinks';
 import withTags from 'editor/plugins/withTags';
 import withVoidElements from 'editor/plugins/withVoidElements';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 
 export type NoteBlock = { text: string; path: Path };
 
@@ -25,10 +26,13 @@ export default function useNoteSearch({
   searchContent = false,
   extendedSearch = false,
 }: NoteSearchOptions = {}) {
+  useEffect(() => {
+    if (searchContent) loadBacklinkIndex();
+  }, [searchContent]);
   const search = useCallback(
     (searchText: string) => {
       const fuse = initFuse(
-        store.getState().notes,
+        searchContent ? store.getState().backlinkNotes : store.getState().notes,
         searchContent,
         extendedSearch
       );

--- a/utils/useTagSearch.ts
+++ b/utils/useTagSearch.ts
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import Fuse from 'fuse.js';
 import { createEditor, Descendant, Editor, Element } from 'slate';
 import { Notes, store } from 'lib/store';
@@ -6,6 +6,7 @@ import withLinks from 'editor/plugins/withLinks';
 import withVoidElements from 'editor/plugins/withVoidElements';
 import withTags from 'editor/plugins/withTags';
 import { ElementType, Tag } from 'types/slate';
+import loadBacklinkIndex from 'lib/api/loadBacklinkIndex';
 
 type FuseDatum = string;
 
@@ -16,9 +17,12 @@ type NoteSearchOptions = {
 export default function useTagSearch({
   numOfResults = -1,
 }: NoteSearchOptions = {}) {
+  useEffect(() => {
+    loadBacklinkIndex();
+  }, []);
   const search = useCallback(
     (searchText: string) => {
-      const fuse = initFuse(store.getState().notes);
+      const fuse = initFuse(store.getState().backlinkNotes);
       return fuse.search(searchText, { limit: numOfResults });
     },
     [numOfResults]


### PR DESCRIPTION
## Summary

Load note metadata at startup and fetch full content only when a note or backlink operation needs it, backed by a sanitized backlink index. Add database and client validation for 5 MB note limits, migrate pasted inline images to file uploads, and preserve existing oversized notes while they shrink. Keep block-reference fallback text synchronized and avoid transient missing-reference errors during index loading.

## Validation

`npm run typecheck`, focused ESLint checks, and `npm test -- --runInBand` (21 tests passed).