### PR TITLE
Delete unused note images from Supabase storage

### DIFF
--- a/__tests__/lib/api/deleteNote.test.ts
+++ b/__tests__/lib/api/deleteNote.test.ts
@@ -1,0 +1,86 @@
+import notes from '__fixtures__/notes';
+import deleteNote from 'lib/api/deleteNote';
+import { store } from 'lib/store';
+import { ElementType, Image } from 'types/slate';
+
+const selectNotes = jest.fn();
+const deleteNotes = jest.fn();
+const updateUser = jest.fn();
+const removeAssets = jest.fn();
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+jest.mock('lib/supabase', () => ({
+  __esModule: true,
+  default: {
+    from: jest.fn((table: string) => {
+      if (table === 'notes') {
+        return {
+          select: jest.fn(() => ({ eq: selectNotes })),
+          delete: jest.fn(() => ({ eq: deleteNotes })),
+        };
+      }
+      return { update: jest.fn(() => ({ eq: updateUser })) };
+    }),
+    storage: {
+      from: jest.fn(() => ({ remove: removeAssets })),
+    },
+  },
+}));
+
+describe('deleteNote', () => {
+  const userId = '1';
+  const noteId = 'note-0';
+  const assetUrl =
+    'https://project.supabase.co/storage/v1/object/sign/user-assets/1/image.png?token=secret';
+  const image: Image = {
+    id: 'image-1',
+    type: ElementType.Image,
+    url: assetUrl,
+    children: [{ text: '' }],
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    store.getState().setNotes({
+      ...notes,
+      [noteId]: { ...notes[noteId], content: [image] },
+    });
+    deleteNotes.mockResolvedValue({ error: null });
+    updateUser.mockResolvedValue({ error: null });
+    removeAssets.mockResolvedValue({ error: null });
+  });
+
+  it('keeps an asset referenced by a note saved during deletion', async () => {
+    selectNotes
+      .mockResolvedValueOnce({ data: [notes[noteId]], error: null })
+      .mockResolvedValueOnce({
+        data: [{ ...notes['note-1'], content: [image] }],
+        error: null,
+      });
+
+    await deleteNote(userId, noteId);
+
+    expect(selectNotes).toHaveBeenCalledTimes(2);
+    expect(removeAssets).not.toHaveBeenCalled();
+  });
+
+  it('deletes an asset that remains unreferenced', async () => {
+    selectNotes
+      .mockResolvedValueOnce({ data: [notes[noteId]], error: null })
+      .mockResolvedValueOnce({ data: [], error: null });
+
+    await deleteNote(userId, noteId);
+
+    expect(removeAssets).toHaveBeenCalledWith(['1/image.png']);
+  });
+
+  it('keeps assets when the final reference check fails', async () => {
+    selectNotes
+      .mockResolvedValueOnce({ data: [notes[noteId]], error: null })
+      .mockResolvedValueOnce({ data: null, error: new Error('offline') });
+
+    await deleteNote(userId, noteId);
+
+    expect(removeAssets).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/lib/storage/userAssets.test.ts
+++ b/__tests__/lib/storage/userAssets.test.ts
@@ -1,0 +1,46 @@
+import { getUserAssetPaths } from 'lib/storage/userAssets';
+
+describe('getUserAssetPaths', () => {
+  const userId = 'user-123';
+
+  it('finds unique uploaded images in nested note content', () => {
+    const uploadedImage =
+      'https://project.supabase.co/storage/v1/object/sign/user-assets/user-123/image.png?token=secret';
+    const content = [
+      {
+        type: 'paragraph',
+        children: [
+          { text: '' },
+          { type: 'image', url: uploadedImage, children: [{ text: '' }] },
+        ],
+      },
+      { type: 'image', url: uploadedImage, children: [{ text: '' }] },
+      {
+        type: 'image',
+        url: 'https://example.com/external.png',
+        children: [{ text: '' }],
+      },
+    ];
+
+    expect(getUserAssetPaths(content, userId)).toEqual(['user-123/image.png']);
+  });
+
+  it('ignores assets that belong to another user', () => {
+    const content = [
+      {
+        type: 'image',
+        url: 'https://project.supabase.co/storage/v1/object/sign/user-assets/another-user/image.png?token=secret',
+        children: [{ text: '' }],
+      },
+    ];
+
+    expect(getUserAssetPaths(content, userId)).toEqual([]);
+  });
+
+  it('handles missing or malformed content', () => {
+    expect(getUserAssetPaths(undefined, userId)).toEqual([]);
+    expect(
+      getUserAssetPaths([{ type: 'image', url: 'not a url' }], userId)
+    ).toEqual([]);
+  });
+});

--- a/lib/api/deleteNote.ts
+++ b/lib/api/deleteNote.ts
@@ -1,11 +1,33 @@
+import * as Sentry from '@sentry/nextjs';
 import { store } from 'lib/store';
 import supabase from 'lib/supabase';
+import { getUserAssetPaths } from 'lib/storage/userAssets';
 
 export default async function deleteNote(userId: string, noteId: string) {
+  const noteAssetPaths = await getNoteAssetPaths(userId, noteId);
+
   // Update note titles in sidebar
   store.getState().deleteNote(noteId);
 
   const response = await supabase.from('notes').delete().eq('id', noteId);
+
+  if (!response.error && noteAssetPaths.length > 0) {
+    const referencedAssetPaths = await getReferencedAssetPaths(userId);
+    if (referencedAssetPaths) {
+      const assetPathsToDelete = noteAssetPaths.filter(
+        (path) => !referencedAssetPaths.has(path)
+      );
+
+      if (assetPathsToDelete.length > 0) {
+        const { error: removeError } = await supabase.storage
+          .from('user-assets')
+          .remove(assetPathsToDelete);
+        if (removeError) {
+          Sentry.captureException(removeError);
+        }
+      }
+    }
+  }
 
   await supabase
     .from('users')
@@ -14,3 +36,50 @@ export default async function deleteNote(userId: string, noteId: string) {
 
   return response;
 }
+
+/**
+ * Returns the asset paths referenced by the given note. The local store can
+ * contain edits that have not reached the database yet, so both sources are
+ * checked before the note is deleted.
+ */
+const getNoteAssetPaths = async (userId: string, noteId: string) => {
+  const { data: dbNotes, error } = await supabase
+    .from('notes')
+    .select('id, content')
+    .eq('id', noteId);
+
+  if (error || !dbNotes) {
+    // If references can't be verified, leave the files alone
+    return [];
+  }
+
+  const allNotes = [...Object.values(store.getState().notes), ...dbNotes];
+  return [
+    ...new Set(
+      allNotes
+        .filter((note) => note.id === noteId)
+        .flatMap((note) => getUserAssetPaths(note.content, userId))
+    ),
+  ];
+};
+
+/**
+ * Returns the assets referenced after the note has been deleted. Fetching the
+ * database again catches references saved by another device during deletion.
+ */
+const getReferencedAssetPaths = async (userId: string) => {
+  const { data: dbNotes, error } = await supabase
+    .from('notes')
+    .select('id, content')
+    .eq('user_id', userId);
+
+  if (error || !dbNotes) {
+    // If references can't be verified, leave the files alone
+    return null;
+  }
+
+  const allNotes = [...Object.values(store.getState().notes), ...dbNotes];
+  return new Set(
+    allNotes.flatMap((note) => getUserAssetPaths(note.content, userId))
+  );
+};

--- a/lib/storage/userAssets.ts
+++ b/lib/storage/userAssets.ts
@@ -1,0 +1,49 @@
+const SIGNED_USER_ASSET_PATH = '/storage/v1/object/sign/user-assets/';
+
+export const getUserAssetPaths = (content: unknown, userId: string) => {
+  const paths = new Set<string>();
+
+  const visit = (value: unknown) => {
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+
+    if (!value || typeof value !== 'object') {
+      return;
+    }
+
+    const node = value as Record<string, unknown>;
+    if (node.type === 'image' && typeof node.url === 'string') {
+      const path = getUserAssetPath(node.url, userId);
+      if (path) {
+        paths.add(path);
+      }
+    }
+
+    if (Array.isArray(node.children)) {
+      visit(node.children);
+    }
+  };
+
+  visit(content);
+  return [...paths];
+};
+
+const getUserAssetPath = (url: string, userId: string) => {
+  try {
+    const pathname = new URL(url).pathname;
+    const markerIndex = pathname.indexOf(SIGNED_USER_ASSET_PATH);
+    if (markerIndex === -1) {
+      return null;
+    }
+
+    const encodedPath = pathname.slice(
+      markerIndex + SIGNED_USER_ASSET_PATH.length
+    );
+    const path = decodeURIComponent(encodedPath);
+    return path.startsWith(`${userId}/`) ? path : null;
+  } catch {
+    return null;
+  }
+};


### PR DESCRIPTION
## Summary

Deleting a note now removes its uploaded Supabase images after the note row is deleted. The cleanup checks local and saved note content before removal, so images that another note still uses are preserved. External images, malformed URLs, assets owned by another user, and unverifiable references are left untouched, while storage errors are reported to Sentry. Tests cover asset path extraction, shared references, successful cleanup, and failed reference checks; TypeScript, ESLint, Prettier, and the focused Jest suite pass.
