### PR TITLE
Stricter free plan limits: 10-note cap and Pro-only image uploads

### DIFF
--- a/__tests__/components/AppLayout.test.tsx
+++ b/__tests__/components/AppLayout.test.tsx
@@ -9,28 +9,28 @@ import notes from '__fixtures__/notes';
 import { Subscription, SubscriptionStatus } from 'types/supabase';
 
 describe('AppLayout', () => {
-  const renderAppLayout = () => {
-    const auth = {
-      isLoaded: true,
-      user: {
-        id: '1',
-        app_metadata: {},
-        user_metadata: {},
-        aud: '',
-        created_at: new Date().toISOString(),
-      },
-      signIn: jest.fn(),
-      signUp: jest.fn(),
-      signOut: jest.fn(),
-    };
-    return render(
-      <AuthContext.Provider value={auth}>
+  const createAuth = () => ({
+    isLoaded: true,
+    user: {
+      id: '1',
+      app_metadata: {},
+      user_metadata: {},
+      aud: '',
+      created_at: new Date().toISOString(),
+    },
+    signIn: jest.fn(),
+    signUp: jest.fn(),
+    signOut: jest.fn(),
+  });
+
+  const renderAppLayout = () =>
+    render(
+      <AuthContext.Provider value={createAuth()}>
         <AppLayout>
           <div>Test</div>
         </AppLayout>
       </AuthContext.Provider>
     );
-  };
 
   beforeEach(() => {
     act(() => {
@@ -87,12 +87,10 @@ describe('AppLayout', () => {
       await waitFor(() => {
         expect(supabaseMock.maybeSingle).toHaveBeenCalled();
       });
-      expect(setBillingDetailsSpy).toHaveBeenCalled();
-
       await waitFor(() => {
-        const billingDetails = store.getState().billingDetails;
-        expect(billingDetails.planId).toBe(PlanId.Pro);
+        expect(setBillingDetailsSpy).toHaveBeenCalled();
       });
+      expect(store.getState().billingDetails.planId).toBe(PlanId.Pro);
     });
 
     it("sets the basic plan if the user is on pro, their subscription is inactive, and they haven't passed their current period end", async () => {
@@ -107,10 +105,10 @@ describe('AppLayout', () => {
       await waitFor(() => {
         expect(supabaseMock.maybeSingle).toHaveBeenCalled();
       });
-      expect(setBillingDetailsSpy).toHaveBeenCalled();
-
-      const billingDetails = store.getState().billingDetails;
-      expect(billingDetails.planId).toBe(PlanId.Basic);
+      await waitFor(() => {
+        expect(setBillingDetailsSpy).toHaveBeenCalled();
+      });
+      expect(store.getState().billingDetails.planId).toBe(PlanId.Basic);
     });
 
     it("sets the basic plan if the user is on pro, their subscription is active, and they've passed their current period end", async () => {
@@ -125,12 +123,10 @@ describe('AppLayout', () => {
       await waitFor(() => {
         expect(supabaseMock.maybeSingle).toHaveBeenCalled();
       });
-      expect(setBillingDetailsSpy).toHaveBeenCalled();
-
       await waitFor(() => {
-        const billingDetails = store.getState().billingDetails;
-        expect(billingDetails.planId).toBe(PlanId.Basic);
+        expect(setBillingDetailsSpy).toHaveBeenCalled();
       });
+      expect(store.getState().billingDetails.planId).toBe(PlanId.Basic);
     });
 
     it('sets the basic plan if the user is on basic', async () => {
@@ -145,12 +141,62 @@ describe('AppLayout', () => {
       await waitFor(() => {
         expect(supabaseMock.maybeSingle).toHaveBeenCalled();
       });
-      expect(setBillingDetailsSpy).toHaveBeenCalled();
+      await waitFor(() => {
+        expect(setBillingDetailsSpy).toHaveBeenCalled();
+      });
+      expect(store.getState().billingDetails.planId).toBe(PlanId.Basic);
+    });
+
+    it('keeps the app loading until billing details are available', async () => {
+      let resolveSubscription: (value: { data: Partial<Subscription> }) => void;
+      const subscription = new Promise<{ data: Partial<Subscription> }>(
+        (resolve) => {
+          resolveSubscription = resolve;
+        }
+      );
+      supabaseMock.maybeSingle.mockImplementation(() => subscription);
+
+      renderAppLayout();
 
       await waitFor(() => {
-        const billingDetails = store.getState().billingDetails;
-        expect(billingDetails.planId).toBe(PlanId.Basic);
+        expect(supabaseMock.maybeSingle).toHaveBeenCalled();
       });
+      expect(screen.getByTestId('spinner')).toBeInTheDocument();
+      expect(screen.queryByText('Test')).not.toBeInTheDocument();
+
+      resolveSubscription!({
+        data: {
+          plan_id: PlanId.Pro,
+          subscription_status: SubscriptionStatus.Active,
+          current_period_end: new Date(Date.now() + 1000).toISOString(),
+        },
+      });
+
+      expect(await screen.findByText('Test')).toBeInTheDocument();
+      expect(store.getState().billingDetails.planId).toBe(PlanId.Pro);
+    });
+
+    it('stays rendered when the user object identity changes, e.g. on token refresh', async () => {
+      mockSubscription({
+        plan_id: PlanId.Pro,
+        subscription_status: SubscriptionStatus.Active,
+        current_period_end: new Date(Date.now() + 1000).toISOString(),
+      });
+
+      const { rerender } = renderAppLayout();
+      expect(await screen.findByText('Test')).toBeInTheDocument();
+
+      // A token refresh produces a new user object with the same id
+      rerender(
+        <AuthContext.Provider value={createAuth()}>
+          <AppLayout>
+            <div>Test</div>
+          </AppLayout>
+        </AuthContext.Provider>
+      );
+
+      expect(screen.getByText('Test')).toBeInTheDocument();
+      expect(screen.queryByTestId('spinner')).not.toBeInTheDocument();
     });
   });
 });

--- a/__tests__/editor/normalizeInlineImages.test.ts
+++ b/__tests__/editor/normalizeInlineImages.test.ts
@@ -1,0 +1,107 @@
+import type { Descendant } from 'slate';
+import { normalizeInlineImages } from 'editor/normalizeInlineImages';
+import { uploadImage } from 'editor/plugins/withImages';
+import { store } from 'lib/store';
+import { BillingFrequency, PlanId } from 'constants/pricing';
+import { ElementType } from 'types/slate';
+
+jest.mock('editor/plugins/withImages', () => ({
+  uploadImage: jest.fn(),
+}));
+
+const DATA_URL = 'data:image/png;base64,abc';
+
+const imageNode = (url: string): Descendant =>
+  ({
+    id: 'image-1',
+    type: ElementType.Image,
+    url,
+    children: [{ text: '' }],
+  } as Descendant);
+
+const paragraphNode = (children: Descendant[]): Descendant =>
+  ({
+    id: 'paragraph-1',
+    type: ElementType.Paragraph,
+    children,
+  } as Descendant);
+
+describe('normalizeInlineImages', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      blob: () => Promise.resolve(new Blob(['test'])),
+    });
+  });
+
+  describe('on the basic plan', () => {
+    beforeEach(() => {
+      store.setState({ billingDetails: { planId: PlanId.Basic } });
+    });
+
+    it('strips embedded images and keeps the rest of the content', async () => {
+      const paragraph = paragraphNode([{ text: 'Hello' }]);
+      const result = await normalizeInlineImages([
+        paragraph,
+        imageNode(DATA_URL),
+      ]);
+
+      expect(result.content).toEqual([paragraph]);
+      expect(result.numOfStrippedImages).toBe(1);
+      expect(uploadImage).not.toHaveBeenCalled();
+    });
+
+    it('leaves an empty text node when stripping empties an element', async () => {
+      const result = await normalizeInlineImages([
+        paragraphNode([imageNode(DATA_URL)]),
+      ]);
+
+      expect(result.content).toEqual([paragraphNode([{ text: '' }])]);
+      expect(result.numOfStrippedImages).toBe(1);
+    });
+
+    it('keeps images with regular urls', async () => {
+      const image = imageNode('https://example.com/image.png');
+      const result = await normalizeInlineImages([image]);
+
+      expect(result.content).toEqual([image]);
+      expect(result.numOfStrippedImages).toBe(0);
+      expect(uploadImage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('on the pro plan', () => {
+    beforeEach(() => {
+      store.setState({
+        billingDetails: {
+          planId: PlanId.Pro,
+          frequency: BillingFrequency.Monthly,
+          currentPeriodEnd: new Date(),
+          cancelAtPeriodEnd: false,
+        },
+      });
+    });
+
+    it('uploads embedded images and replaces their urls', async () => {
+      (uploadImage as jest.Mock).mockResolvedValue(
+        'https://example.com/signed-url'
+      );
+
+      const result = await normalizeInlineImages([imageNode(DATA_URL)]);
+
+      expect(result.content).toEqual([
+        imageNode('https://example.com/signed-url'),
+      ]);
+      expect(result.numOfStrippedImages).toBe(0);
+      expect(uploadImage).toHaveBeenCalled();
+    });
+
+    it('throws if an embedded image fails to upload', async () => {
+      (uploadImage as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        normalizeInlineImages([imageNode(DATA_URL)])
+      ).rejects.toThrow('The embedded image could not be uploaded.');
+    });
+  });
+});

--- a/__tests__/editor/withImages.test.ts
+++ b/__tests__/editor/withImages.test.ts
@@ -1,0 +1,97 @@
+import { toast } from 'react-toastify';
+import { uploadImage } from 'editor/plugins/withImages';
+import { store } from 'lib/store';
+import supabase from 'lib/supabase';
+import { BillingFrequency, PlanId } from 'constants/pricing';
+
+jest.mock('react-toastify', () => ({
+  toast: {
+    error: jest.fn(),
+    info: jest.fn(() => 'toast-id'),
+    dismiss: jest.fn(),
+  },
+}));
+
+const upload = jest.fn();
+const createSignedUrl = jest.fn();
+
+jest.mock('lib/supabase', () => ({
+  auth: {
+    getSession: jest.fn(),
+  },
+  storage: {
+    from: () => ({
+      upload: (...args: unknown[]) => upload(...args),
+      createSignedUrl: (...args: unknown[]) => createSignedUrl(...args),
+    }),
+  },
+}));
+
+describe('uploadImage', () => {
+  const file = new File(['test'], 'test.png', { type: 'image/png' });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (supabase.auth.getSession as jest.Mock).mockResolvedValue({
+      data: { session: { user: { id: 'user-1' } } },
+    });
+    upload.mockResolvedValue({ error: null });
+    createSignedUrl.mockResolvedValue({
+      data: { signedUrl: 'https://example.com/signed-url' },
+      error: null,
+    });
+    store.setState({
+      billingDetails: { planId: PlanId.Basic },
+      isUpgradeModalOpen: false,
+    });
+  });
+
+  it('blocks uploads on the basic plan', async () => {
+    const result = await uploadImage(file);
+
+    expect(result).toBeNull();
+    expect(upload).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      'Image uploads are only available on the Pro plan. Upgrade to upload images.'
+    );
+    expect(store.getState().isUpgradeModalOpen).toBe(true);
+  });
+
+  it('uploads images on the pro plan', async () => {
+    store.setState({
+      billingDetails: {
+        planId: PlanId.Pro,
+        frequency: BillingFrequency.Monthly,
+        currentPeriodEnd: new Date(),
+        cancelAtPeriodEnd: false,
+      },
+    });
+
+    const result = await uploadImage(file);
+
+    expect(result).toBe('https://example.com/signed-url');
+    expect(upload).toHaveBeenCalled();
+    expect(store.getState().isUpgradeModalOpen).toBe(false);
+  });
+
+  it('rejects images over 20 MB on the pro plan', async () => {
+    store.setState({
+      billingDetails: {
+        planId: PlanId.Pro,
+        frequency: BillingFrequency.Monthly,
+        currentPeriodEnd: new Date(),
+        cancelAtPeriodEnd: false,
+      },
+    });
+    const largeFile = new File([''], 'large.png', { type: 'image/png' });
+    Object.defineProperty(largeFile, 'size', { value: 20 * 1024 * 1024 + 1 });
+
+    const result = await uploadImage(largeFile);
+
+    expect(result).toBeNull();
+    expect(upload).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledWith(
+      'Your image is over the 20 MB limit. Please upload a smaller image.'
+    );
+  });
+});

--- a/components/AppLayout.tsx
+++ b/components/AppLayout.tsx
@@ -3,7 +3,6 @@ import type { ReactNode } from 'react';
 import { useRouter } from 'next/router';
 import Head from 'next/head';
 import { toast } from 'react-toastify';
-import type { User } from '@supabase/supabase-js';
 import classNames from 'classnames';
 import colors from 'tailwindcss/colors';
 import { useStore, store, NoteTreeItem, Notes, SidebarTab } from 'lib/store';
@@ -34,6 +33,8 @@ export default function AppLayout(props: Props) {
   const { user, isLoaded } = useAuth();
   const router = useRouter();
   const [isPageLoaded, setIsPageLoaded] = useState(false);
+  const [isStoreLoaded, setIsStoreLoaded] = useState(false);
+  const [areBillingDetailsLoaded, setAreBillingDetailsLoaded] = useState(false);
 
   const setIsSidebarOpen = useStore((state) => state.setIsSidebarOpen);
   const setIsPageStackingOn = useStore((state) => state.setIsPageStackingOn);
@@ -45,6 +46,7 @@ export default function AppLayout(props: Props) {
         name: `notabase-storage-${user.id}`,
       });
       await store.persist.rehydrate();
+      setIsStoreLoaded(true);
 
       // If the user is mobile, change the initial values of isSidebarOpen and isPageStackingOn to better suit mobile devices
       // TODO: ideally this change would be temporary so that we don't override the user's existing values
@@ -157,38 +159,54 @@ export default function AppLayout(props: Props) {
 
   const setBillingDetails = useStore((state) => state.setBillingDetails);
   const initBillingDetails = useCallback(
-    async (user: User) => {
-      const { data } = await supabase
-        .from('subscriptions')
-        .select(
-          'plan_id, subscription_status, frequency, current_period_end, cancel_at_period_end'
-        )
-        .eq('user_id', user.id)
-        .maybeSingle();
+    async (userId: string) => {
+      try {
+        const { data } = await supabase
+          .from('subscriptions')
+          .select(
+            'plan_id, subscription_status, frequency, current_period_end, cancel_at_period_end'
+          )
+          .eq('user_id', userId)
+          .maybeSingle();
 
-      if (data) {
-        const currentPeriodEndDate = new Date(data.current_period_end);
-        const isSubscriptionActiveAndNotEnded =
-          data.subscription_status === SubscriptionStatus.Active &&
-          Date.now() < currentPeriodEndDate.getTime();
+        if (data) {
+          const currentPeriodEndDate = new Date(data.current_period_end);
+          const isSubscriptionActiveAndNotEnded =
+            data.subscription_status === SubscriptionStatus.Active &&
+            Date.now() < currentPeriodEndDate.getTime();
 
-        setBillingDetails({
-          planId: isSubscriptionActiveAndNotEnded ? data.plan_id : PlanId.Basic,
-          frequency: data.frequency,
-          currentPeriodEnd: currentPeriodEndDate,
-          cancelAtPeriodEnd: data.cancel_at_period_end,
-        });
+          setBillingDetails({
+            planId: isSubscriptionActiveAndNotEnded
+              ? data.plan_id
+              : PlanId.Basic,
+            frequency: data.frequency,
+            currentPeriodEnd: currentPeriodEndDate,
+            cancelAtPeriodEnd: data.cancel_at_period_end,
+          });
+        } else {
+          setBillingDetails({ planId: PlanId.Basic });
+        }
+      } catch {
+        setBillingDetails({ planId: PlanId.Basic });
+      } finally {
+        setAreBillingDetailsLoaded(true);
       }
     },
     [setBillingDetails]
   );
 
+  // Key this effect on the user id rather than the user object: auth events
+  // like token refreshes produce a new user object for the same user, and
+  // resetting the loading state for those would unmount the app to a spinner
+  const userId = user?.id;
   useEffect(() => {
-    if (!user) {
+    if (!userId || !isStoreLoaded) {
+      setAreBillingDetailsLoaded(false);
       return;
     }
-    initBillingDetails(user);
-  }, [initBillingDetails, user]);
+    setAreBillingDetailsLoaded(false);
+    initBillingDetails(userId);
+  }, [initBillingDetails, isStoreLoaded, userId]);
 
   const [isFindOrCreateModalOpen, setIsFindOrCreateModalOpen] = useState(false);
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
@@ -345,7 +363,7 @@ export default function AppLayout(props: Props) {
     </Head>
   );
 
-  if (!isPageLoaded) {
+  if (!isPageLoaded || !areBillingDetailsLoaded) {
     return (
       <>
         {head}

--- a/components/PricingPlan.tsx
+++ b/components/PricingPlan.tsx
@@ -1,13 +1,18 @@
 import { ReactNode } from 'react';
 import Link from 'next/link';
 import classNames from 'classnames';
-import { IconCheck } from '@tabler/icons';
+import { IconCheck, IconX } from '@tabler/icons';
+
+export type BulletPoint = {
+  text: string;
+  included: boolean;
+};
 
 type Props = {
   name: string;
   price: number;
   period: string;
-  bulletPoints: string[];
+  bulletPoints: (string | BulletPoint)[];
   discount?: string;
   button?: ReactNode;
   className?: string;
@@ -46,14 +51,24 @@ const PricingPlan = (props: Props) => {
       </div>
       <div className="flex flex-1 flex-col p-6 sm:p-10 sm:pt-6">
         <ul className="flex-1 space-y-4">
-          {bulletPoints.map((bulletPoint, index) => (
-            <li key={index} className="flex items-start">
-              <IconCheck className="flex-shrink-0 text-green-500" />
-              <p className="ml-3 leading-6 text-gray-700 dark:text-gray-200">
-                {bulletPoint}
-              </p>
-            </li>
-          ))}
+          {bulletPoints.map((bulletPoint, index) => {
+            const { text, included } =
+              typeof bulletPoint === 'string'
+                ? { text: bulletPoint, included: true }
+                : bulletPoint;
+            return (
+              <li key={index} className="flex items-start">
+                {included ? (
+                  <IconCheck className="flex-shrink-0 text-green-500" />
+                ) : (
+                  <IconX className="flex-shrink-0 text-red-500" />
+                )}
+                <p className="ml-3 leading-6 text-gray-700 dark:text-gray-200">
+                  {text}
+                </p>
+              </li>
+            );
+          })}
         </ul>
         <div className="mt-6">
           {button ?? (

--- a/components/PricingPlans.tsx
+++ b/components/PricingPlans.tsx
@@ -6,16 +6,16 @@ import {
   PlanId,
   PRICING_PLANS,
 } from 'constants/pricing';
-import PricingPlan from './PricingPlan';
+import PricingPlan, { BulletPoint } from './PricingPlan';
 import Toggle from './Toggle';
 
-const BASIC_BULLET_POINTS = [
+const BASIC_BULLET_POINTS: (string | BulletPoint)[] = [
   'Try it out for free',
   'Easy-to-use and powerful editor',
   'Graph view',
   'Import/export your notes at any time',
   `${MAX_NUM_OF_BASIC_NOTES} notes`,
-  '5 MB image uploads',
+  { text: 'No image uploads', included: false },
   'Community support',
 ];
 

--- a/components/UpgradeBanner.tsx
+++ b/components/UpgradeBanner.tsx
@@ -12,7 +12,7 @@ export default function UpgradeBanner() {
   const showUpgradeBanner = useMemo(
     () =>
       billingDetails.planId === PlanId.Basic &&
-      numOfNotes >= MAX_NUM_OF_BASIC_NOTES - 10,
+      numOfNotes >= MAX_NUM_OF_BASIC_NOTES - 2,
     [billingDetails, numOfNotes]
   );
 

--- a/constants/pricing.ts
+++ b/constants/pricing.ts
@@ -54,7 +54,7 @@ export type Plan<Prices extends PlanPrices> = {
   features: readonly PlanFeature[];
 };
 
-export const MAX_NUM_OF_BASIC_NOTES = 100;
+export const MAX_NUM_OF_BASIC_NOTES = 10;
 
 const BASIC_FEATURES: PlanFeature[] = [
   { name: Feature.NumOfNotes, amount: MAX_NUM_OF_BASIC_NOTES },

--- a/editor/normalizeInlineImages.ts
+++ b/editor/normalizeInlineImages.ts
@@ -1,5 +1,7 @@
 import { Element, type Descendant } from 'slate';
 import { ElementType, type Image } from 'types/slate';
+import { store } from 'lib/store';
+import { PlanId } from 'constants/pricing';
 import { uploadImage } from './plugins/withImages';
 
 const DATA_IMAGE_PATTERN = /^data:(image\/[a-z0-9.+-]+);base64,/i;
@@ -12,27 +14,53 @@ const dataUrlToFile = async (url: string) => {
   return new File([blob], `pasted-image.${extension}`, { type: match[1] });
 };
 
+export type NormalizedInlineImages = {
+  content: Descendant[];
+  numOfStrippedImages: number;
+};
+
 export const normalizeInlineImages = async (
   nodes: Descendant[]
-): Promise<Descendant[]> =>
-  Promise.all(
-    nodes.map(async (node): Promise<Descendant> => {
-      if (!Element.isElement(node)) return node;
+): Promise<NormalizedInlineImages> => {
+  let numOfStrippedImages = 0;
 
-      let normalized = node;
-      if (
-        node.type === ElementType.Image &&
-        DATA_IMAGE_PATTERN.test(node.url)
-      ) {
-        const file = await dataUrlToFile(node.url);
-        const url = file ? await uploadImage(file) : null;
-        if (!url) throw new Error('The embedded image could not be uploaded.');
-        normalized = { ...node, url } as Image;
-      }
+  const normalizeNodes = async (nodes: Descendant[]): Promise<Descendant[]> => {
+    const normalizedNodes = await Promise.all(
+      nodes.map(async (node): Promise<Descendant | null> => {
+        if (!Element.isElement(node)) return node;
 
-      return {
-        ...normalized,
-        children: await normalizeInlineImages(normalized.children),
-      } as Descendant;
-    })
-  );
+        let normalized = node;
+        if (
+          node.type === ElementType.Image &&
+          DATA_IMAGE_PATTERN.test(node.url)
+        ) {
+          // Users on the basic plan cannot upload images, so strip embedded
+          // images instead of failing the whole paste or import
+          if (store.getState().billingDetails.planId === PlanId.Basic) {
+            numOfStrippedImages++;
+            return null;
+          }
+          const file = await dataUrlToFile(node.url);
+          const url = file ? await uploadImage(file) : null;
+          if (!url)
+            throw new Error('The embedded image could not be uploaded.');
+          normalized = { ...node, url } as Image;
+        }
+
+        const children = await normalizeNodes(normalized.children);
+        return {
+          ...normalized,
+          // Slate elements must have at least one child
+          children: children.length > 0 ? children : [{ text: '' }],
+        } as Descendant;
+      })
+    );
+
+    return normalizedNodes.filter((node): node is Descendant => node !== null);
+  };
+
+  return {
+    content: await normalizeNodes(nodes),
+    numOfStrippedImages,
+  };
+};

--- a/editor/plugins/withHtml.ts
+++ b/editor/plugins/withHtml.ts
@@ -118,7 +118,16 @@ const withHtml = (editor: Editor) => {
       if (parsed.querySelector('img[src^="data:image/"]')) {
         const fragment = deserialize(parsed.body) as Descendant[];
         normalizeInlineImages(fragment)
-          .then((normalized) => Transforms.insertFragment(editor, normalized))
+          .then(({ content, numOfStrippedImages }) => {
+            if (numOfStrippedImages > 0) {
+              toast.warn(
+                'Embedded images were removed. Image uploads are only available on the Pro plan.'
+              );
+            }
+            if (content.length > 0) {
+              Transforms.insertFragment(editor, content);
+            }
+          })
           .catch(() =>
             toast.error(
               'The pasted image could not be uploaded. Please try again.'

--- a/editor/plugins/withImages.ts
+++ b/editor/plugins/withImages.ts
@@ -67,19 +67,16 @@ export const uploadImage = async (file: File): Promise<string | null> => {
   }
 
   // Enforce upload limits
-  const BASIC_UPLOAD_LIMIT = 5 * 1024 * 1024; // 5 MB
   const PRO_UPLOAD_LIMIT = 20 * 1024 * 1024; // 20 MB
   const planId = store.getState().billingDetails.planId;
 
-  if (planId === PlanId.Basic && file.size > BASIC_UPLOAD_LIMIT) {
+  if (planId === PlanId.Basic) {
     toast.error(
-      'Your image is over the 5 MB limit. Upgrade to the Pro plan for 20 MB file uploads.'
+      'Image uploads are only available on the Pro plan. Upgrade to upload images.'
     );
+    store.getState().setIsUpgradeModalOpen(true);
     return null;
-  } else if (
-    (planId === PlanId.Pro || planId === PlanId.Catalyst) &&
-    file.size > PRO_UPLOAD_LIMIT
-  ) {
+  } else if (file.size > PRO_UPLOAD_LIMIT) {
     toast.error(
       'Your image is over the 20 MB limit. Please upload a smaller image.'
     );

--- a/supabase/migrations/20260711120000_restrict_basic_user_asset_uploads.sql
+++ b/supabase/migrations/20260711120000_restrict_basic_user_asset_uploads.sql
@@ -1,11 +1,3 @@
--- Create storage bucket
-
-insert into storage.buckets (id, name)
-values ('user-assets', 'user-assets');
-
-
--- Add row-level-security policy for storage
-
 create or replace function public.can_upload_user_asset()
 returns boolean
 language sql
@@ -27,11 +19,15 @@ revoke all on function public.can_upload_user_asset() from public;
 grant execute on function public.can_upload_user_asset() to authenticated;
 
 drop policy if exists "Access to user's file uploads" on storage.objects;
+
 create policy "Access to user's file uploads"
 on storage.objects for all
-using ((bucket_id='user-assets'::text) AND ((auth.uid())::text=(storage.foldername(name))[1]))
+using (
+  bucket_id = 'user-assets'
+  and (auth.uid())::text = (storage.foldername(name))[1]
+)
 with check (
-  (bucket_id='user-assets'::text)
-  AND ((auth.uid())::text=(storage.foldername(name))[1])
-  AND public.can_upload_user_asset()
+  bucket_id = 'user-assets'
+  and (auth.uid())::text = (storage.foldername(name))[1]
+  and public.can_upload_user_asset()
 );

--- a/utils/useImport.ts
+++ b/utils/useImport.ts
@@ -149,6 +149,7 @@ export default function useImport() {
       const upsertData: NoteInsert[] = [];
       const noteLinkUpsertData: NoteInsert[] = [];
       const noteTitleToIdCache: Record<string, string | undefined> = {};
+      let numOfStrippedImages = 0;
       for (const file of inputElement.files) {
         const fileName = file.name.replace(/\.[^/.]+$/, ''); // Remove file extension
         if (!fileName) {
@@ -167,7 +168,9 @@ export default function useImport() {
           fixNoteLinks(result as Descendant[], noteTitleToIdCache);
         let slateContent;
         try {
-          slateContent = await normalizeInlineImages(parsedContent);
+          const normalized = await normalizeInlineImages(parsedContent);
+          slateContent = normalized.content;
+          numOfStrippedImages += normalized.numOfStrippedImages;
         } catch (error) {
           toast.dismiss(importingToast);
           toast.error(
@@ -223,6 +226,12 @@ export default function useImport() {
         );
       } else {
         toast.error('No notes were imported.');
+      }
+
+      if (numOfStrippedImages > 0) {
+        toast.warn(
+          'Embedded images were removed. Image uploads are only available on the Pro plan.'
+        );
       }
     };
 


### PR DESCRIPTION
Lowers the Basic plan note limit from 100 to 10 and makes image uploads Pro-only, enforced both client-side (with an upgrade prompt) and server-side via a new storage RLS policy and migration that checks for an active Pro/Catalyst subscription.

The app now waits for billing details before rendering so plan checks never run against a stale default, keyed on the user id so token refreshes don't unmount the app to a spinner. Pasting or importing content with embedded images on the Basic plan strips the images with a single warning toast instead of dropping the pasted text or aborting the import. The pricing page marks image uploads as excluded from Basic with a red X, and the upgrade banner now appears 2 notes before the limit. Adds tests for the upload plan gating, embedded-image normalization, and the billing loading gate.