### PR TITLE
Show annual pricing as a monthly rate

### DIFF
--- a/components/PricingPlan.tsx
+++ b/components/PricingPlan.tsx
@@ -12,6 +12,7 @@ type Props = {
   name: string;
   price: number;
   period: string;
+  billingNote?: string;
   bulletPoints: (string | BulletPoint)[];
   discount?: string;
   button?: ReactNode;
@@ -19,8 +20,16 @@ type Props = {
 };
 
 const PricingPlan = (props: Props) => {
-  const { name, price, period, discount, bulletPoints, button, className } =
-    props;
+  const {
+    name,
+    price,
+    period,
+    billingNote,
+    discount,
+    bulletPoints,
+    button,
+    className,
+  } = props;
 
   const pricingPlanClassName = classNames(
     'flex flex-col rounded-lg border overflow-hidden shadow-md',
@@ -47,9 +56,16 @@ const PricingPlan = (props: Props) => {
               {period}
             </span>
           </div>
+          {billingNote ? (
+            <p className="mt-2 text-sm text-gray-500">{billingNote}</p>
+          ) : null}
         </div>
       </div>
-      <div className="flex flex-1 flex-col p-6 sm:p-10 sm:pt-6">
+      <div
+        className={classNames('flex flex-1 flex-col p-6 sm:p-10 sm:pt-6', {
+          '-mt-7': billingNote,
+        })}
+      >
         <ul className="flex-1 space-y-4">
           {bulletPoints.map((bulletPoint, index) => {
             const { text, included } =

--- a/components/PricingPlans.tsx
+++ b/components/PricingPlans.tsx
@@ -10,7 +10,6 @@ import PricingPlan, { BulletPoint } from './PricingPlan';
 import Toggle from './Toggle';
 
 const BASIC_BULLET_POINTS: (string | BulletPoint)[] = [
-  'Try it out for free',
   'Easy-to-use and powerful editor',
   'Graph view',
   'Import/export your notes at any time',
@@ -34,6 +33,8 @@ type Props = {
 export default function PricingPlans(props: Props) {
   const { buttons } = props;
   const [showAnnual, setShowAnnual] = useState(true);
+  const proAnnualPrice =
+    PRICING_PLANS[PlanId.Pro].prices[BillingFrequency.Annual].amount / 100;
 
   const getBillingPeriodPrice = useCallback(
     (planId: PlanId, showAnnual: boolean) => {
@@ -46,7 +47,11 @@ export default function PricingPlans(props: Props) {
       } else {
         price = plan.prices[BillingFrequency.OneTime];
       }
-      return +(price.amount / 100).toFixed(2);
+      const amount =
+        showAnnual && isSubscription(plan.prices)
+          ? price.amount / 12
+          : price.amount;
+      return +(amount / 100).toFixed(2);
     },
     []
   );
@@ -74,7 +79,7 @@ export default function PricingPlans(props: Props) {
           className="mx-auto w-full lg:w-full"
           name={PRICING_PLANS[PlanId.Basic].name}
           price={getBillingPeriodPrice(PlanId.Basic, showAnnual)}
-          period={showAnnual ? '/ yr' : '/ mo'}
+          period="/ mo"
           bulletPoints={BASIC_BULLET_POINTS}
           button={buttons?.(showAnnual)[0]}
         />
@@ -82,7 +87,10 @@ export default function PricingPlans(props: Props) {
           className="mx-auto w-full lg:w-full"
           name={PRICING_PLANS[PlanId.Pro].name}
           price={getBillingPeriodPrice(PlanId.Pro, showAnnual)}
-          period={showAnnual ? '/ yr' : '/ mo'}
+          period="/ mo"
+          billingNote={
+            showAnnual ? `Billed annually at $${proAnnualPrice}` : undefined
+          }
           bulletPoints={PRO_BULLET_POINTS}
           button={buttons?.(showAnnual)[1]}
         />


### PR DESCRIPTION
## Summary

Show annual pricing as its monthly equivalent while making the annual charge clear. Keep the plan feature lists aligned and remove the redundant “Try it out for free” Basic-plan bullet.

## Validation

Ran TypeScript, ESLint, Prettier, and diff checks.
