### PR TITLE
Update sponsor listings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ If you need help getting started with Notabase, check out our [Help Center](http
 
 ## Sponsors
 
-Special thanks to the following people for their support:
+Special thanks to the following companies for their support:
 
-- [@Jaydon-chai](https://github.com/Jaydon-chai)
+- [Fluxmail](https://fluxmail.ai?ref=notabase.io)
+- [ExploreJobs.ai](https://explorejobs.ai?ref=notabase.io)
 
 Sponsors make it possible for me to continue developing Notabase. Your support is greatly appreciated!
 

--- a/pages/sponsors.tsx
+++ b/pages/sponsors.tsx
@@ -10,17 +10,15 @@ export default function Sponsors() {
       <div className="prose-primary container prose px-6 py-16 lg:prose-xl">
         <h1>Sponsors</h1>
         <div>
-          <p>
-            Special thanks to the following people/companies for their support:
-          </p>
+          <p>Special thanks to the following companies for their support:</p>
           <ul>
             <li>
               <a
-                href="https://github.com/Jaydon-chai"
+                href="https://fluxmail.ai?ref=notabase.io"
                 target="_blank"
                 rel="noopener noreferrer"
               >
-                @Jaydon-chai
+                Fluxmail
               </a>
             </li>
             <li>
@@ -30,15 +28,6 @@ export default function Sponsors() {
                 rel="noopener noreferrer"
               >
                 ExploreJobs.ai
-              </a>
-            </li>
-            <li>
-              <a
-                href="https://www.fluxmail.ai?ref=notabase.io"
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Fluxmail
               </a>
             </li>
           </ul>


### PR DESCRIPTION
## Summary

- remove Jaydon Chai from the sponsor listings
- add Fluxmail and ExploreJobs.ai to the README, with Fluxmail listed first
- use the same sponsor order and Fluxmail URL on the sponsors page

## Validation

- `git diff --check origin/main...HEAD`
