### PR TITLE
Remove beta status from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,6 @@ It is inspired by note-taking apps such as Notion, Obsidian, Typora, and Roam Re
 - 🙌 **Open source** with community involvement and transparent development
 - 🚀 And much more!
 
-## Status
-
-Notabase is in beta and is under active development.
-
 ## Documentation & Support
 
 If you need help getting started with Notabase, check out our [Help Center](https://notabase.io/publish/ed280468-4096-4b21-8298-4a97c4eb990e/note/59df6332-0356-4c06-83ba-a90682ab18fc/).


### PR DESCRIPTION
Removes the Status section from the README, which described Notabase as being in beta and under active development.